### PR TITLE
test: match concurrent MCP responses by id

### DIFF
--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -127,9 +127,10 @@ class RtaBrainMcpTests(unittest.TestCase):
             self.assertEqual(result.returncode, 0, result.stderr)
             payloads = responses(result.stdout)
             self.assertEqual(len(payloads), 4)
-            search_text = payloads[2]["result"]["content"][0]["text"]
+            payloads_by_id = {payload["id"]: payload for payload in payloads}
+            search_text = payloads_by_id[3]["result"]["content"][0]["text"]
             self.assertIn("Rta-Smriti", search_text)
-            pack_text = payloads[3]["result"]["content"][0]["text"]
+            pack_text = payloads_by_id[4]["result"]["content"][0]["text"]
             self.assertIn("# Rta-Smriti Context Pack", pack_text)
             self.assertIn("Pramana: anumana", pack_text)
 


### PR DESCRIPTION
## Summary
- identify concurrent JSON-RPC tool responses by protocol `id`
- remove a platform-timing-dependent assertion from the release gate

## Evidence
- focused MCP test passed 40 consecutive runs locally
- full Python suite: 182 passed, 6 skipped
- privacy scan: PASS
- diff check: PASS

This follow-up was discovered by the post-merge `main` gate. It changes test logic only; product runtime code is unchanged.