### PR TITLE
Improve v0.4 launch trust and Product Hunt discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 ![Rta-Smriti Brain - Give every project a memory](launch-assets/social/github-social-preview.png)
 
+[![CI](https://github.com/sulabhdubey/rta-smriti-brain/actions/workflows/ci.yml/badge.svg)](https://github.com/sulabhdubey/rta-smriti-brain/actions/workflows/ci.yml)
+[![Cross-platform binaries](https://github.com/sulabhdubey/rta-smriti-brain/actions/workflows/binaries.yml/badge.svg)](https://github.com/sulabhdubey/rta-smriti-brain/actions/workflows/binaries.yml)
+[![Release](https://img.shields.io/github/v/release/sulabhdubey/rta-smriti-brain?include_prereleases&label=release)](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v0.4.0-alpha)
+[![License: MIT](https://img.shields.io/badge/license-MIT-2ea44f.svg)](LICENSE)
+
 **A local project brain for AI coding agents.**
 
 [Download v0.4.0-alpha](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v0.4.0-alpha) · [Live website](https://sulabhdubey.github.io/rta-smriti-brain/) · [60-second product demo](launch-assets/product-hunt/rta-smriti-launch-demo.mp4) · [Installation](docs/INSTALLATION.md) · [Usage guide](docs/USAGE_GUIDE.md) · [Architecture](docs/ARCHITECTURE.md) · [Public benchmark](docs/PUBLIC_BENCHMARK.md) · [Release verification](docs/RELEASE_VERIFICATION.md) · [Security](SECURITY.md) · [Roadmap](ROADMAP.md)

--- a/launch-assets/press/PRODUCT_FACT_SHEET.md
+++ b/launch-assets/press/PRODUCT_FACT_SHEET.md
@@ -2,9 +2,9 @@
 
 **Category:** Open-source developer tool, local AI project memory
 
-**Release candidate:** `0.4.0-alpha`; publication target: `main`
+**Current release:** [`v0.4.0-alpha`](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v0.4.0-alpha)
 
-**Release state:** The `v0.4.0-alpha` tag and GitHub Release are intentionally not created.
+**Release state:** Published as a GitHub prerelease on August 16, 2026, with SHA-256 checksums, a wheel, and standalone Windows, Linux, and macOS artifacts.
 
 **License:** MIT
 
@@ -18,6 +18,6 @@
 
 **Privacy:** Local SQLite storage, loopback-only console, no account, no telemetry, no hosted database.
 
-**Validation:** See `docs/RELEASE_VERIFICATION.md` for current, reproducible checks. Historical test counts and private-project scale claims are intentionally excluded from this fact sheet.
+**Validation:** See [`docs/RELEASE_VERIFICATION.md`](../../docs/RELEASE_VERIFICATION.md) for current, reproducible checks and [`docs/PUBLIC_BENCHMARK.md`](../../docs/PUBLIC_BENCHMARK.md) for the privacy-safe synthetic benchmark. Historical test counts and private-project scale claims are intentionally excluded from this fact sheet.
 
 **Primary differentiator:** Repository evidence, durable human memory, session handoffs, evidence class, freshness, and agent-ready context are combined in one inspectable local layer.

--- a/launch-site/src/main.jsx
+++ b/launch-site/src/main.jsx
@@ -15,6 +15,7 @@ import {
   GitBranch,
   LockKeyhole,
   Menu,
+  MessageCircle,
   Network,
   Play,
   Search,
@@ -27,6 +28,7 @@ import {
 import "./styles.css";
 
 const repositoryUrl = import.meta.env.VITE_REPOSITORY_URL || "https://github.com/sulabhdubey/rta-smriti-brain";
+const productHuntUrl = "https://www.producthunt.com/products/rta-smriti-brain?launch=rta-smriti-brain&utm_source=website&utm_medium=referral&utm_campaign=v040_launch";
 
 const installCommand = "python -m pip install .";
 const agents = ["Codex", "Claude Code", "Cursor", "Copilot", "Gemini CLI", "Aider", "Cline", "Any MCP agent"];
@@ -85,6 +87,7 @@ function Hero() {
           <a className="primaryAction" href="#install"><TerminalSquare size={18} /> Get started <ArrowRight size={17} /></a>
           <a className="secondaryAction" href="#demo"><Play size={17} /> Watch the product</a>
         </div>
+        <a className="launchConversation" href={productHuntUrl}><MessageCircle size={15} /> Live on Product Hunt <span>Join the conversation</span><ExternalLink size={13} /></a>
         <div className="heroProof" aria-label="Product proof points">
           <span><strong>6</strong> synthetic benchmark queries</span>
           <span><strong>10,000</strong> synthetic files profiled</span>
@@ -287,7 +290,7 @@ function Install() {
 
 function Footer() {
   return (
-    <footer><div className="shell footerGrid"><Brand compact /><p>Project memory that stays with the project.</p><div><a href="#install">Install</a><a href="#difference">Security & privacy</a><a href="./LICENSE.txt">MIT License</a>{repositoryUrl && <a href={repositoryUrl}>Get source <ExternalLink size={13} /></a>}</div></div></footer>
+    <footer><div className="shell footerGrid"><Brand compact /><p>Project memory that stays with the project.</p><div><a href="#install">Install</a><a href="#difference">Security & privacy</a><a href="./LICENSE.txt">MIT License</a><a href={productHuntUrl}>Product Hunt <ExternalLink size={13} /></a>{repositoryUrl && <a href={repositoryUrl}>Get source <ExternalLink size={13} /></a>}</div></div></footer>
   );
 }
 

--- a/launch-site/src/styles.css
+++ b/launch-site/src/styles.css
@@ -53,6 +53,10 @@ img { display: block; max-width: 100%; }
 .primaryAction { color: #021415; background: var(--teal); box-shadow: 0 13px 36px rgba(94,234,212,.15); }
 .secondaryAction { color: #e4f3ff; border: 1px solid rgba(255,255,255,.2); background: rgba(5,12,18,.78); }
 .primaryAction:hover, .secondaryAction:hover { transform: translateY(-1px); }
+.launchConversation { display: inline-flex; align-items: center; align-self: flex-start; gap: 7px; margin-top: 15px; color: #b9ccd9; font-size: 12px; }
+.launchConversation svg:first-child { color: var(--teal); }
+.launchConversation span { color: var(--teal); font-weight: 750; }
+.launchConversation:hover { color: white; }
 .heroProof { display: flex; gap: 27px; margin-top: 38px; color: #8ea6b9; font-size: 11px; }
 .heroProof span { display: grid; gap: 3px; padding-left: 12px; border-left: 1px solid rgba(94,234,212,.35); }
 .heroProof strong { color: #effbff; font-size: 19px; }


### PR DESCRIPTION
## Summary
- add CI, cross-platform artifact, release, and license trust badges
- correct the public v0.4 fact sheet
- link the active Product Hunt conversation from the launch website

## Verification
- npm run build:launch
- npm run test:launch
- git diff --check

No private project data or credentials are included.