### PR TITLE
fix: scan nested release artifacts

### DIFF
--- a/scripts/privacy_scan.py
+++ b/scripts/privacy_scan.py
@@ -117,6 +117,24 @@ def is_known_path_definition(relative: str, view: bytes, start: int, end: int) -
     return digest in allowed
 
 
+def _git_repository_root(root: Path) -> Path | None:
+    result = run_git_inspection(
+        root,
+        "rev-parse",
+        "--show-toplevel",
+        max_output_bytes=4_096,
+    )
+    if result is None or result.returncode != 0:
+        return None
+    value = result.stdout.strip()
+    if not value:
+        return None
+    try:
+        return Path(value).expanduser().resolve(strict=True)
+    except (OSError, RuntimeError):
+        return None
+
+
 def candidate_files(root: Path, budget: ScanBudget) -> list[Path]:
     candidates: list[Path] = []
 
@@ -128,23 +146,25 @@ def candidate_files(root: Path, budget: ScanBudget) -> list[Path]:
             raise ScanFileLimitExceeded
         candidates.append(path)
 
-    result = run_git_inspection(
-        root,
-        "ls-files",
-        "--cached",
-        "--others",
-        "--exclude-standard",
-        "-z",
-        max_output_bytes=MAX_ARCHIVE_TOTAL_BYTES,
-    )
-    if result is not None and result.returncode == 0:
-        for item in result.stdout.split("\0"):
-            if not item:
-                continue
-            path = root / item
-            if os.path.lexists(path):
-                add_candidate(path)
-        return candidates
+    git_root = _git_repository_root(root)
+    if git_root == root:
+        result = run_git_inspection(
+            root,
+            "ls-files",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+            "-z",
+            max_output_bytes=MAX_ARCHIVE_TOTAL_BYTES,
+        )
+        if result is not None and result.returncode == 0:
+            for item in result.stdout.split("\0"):
+                if not item:
+                    continue
+                path = root / item
+                if os.path.lexists(path):
+                    add_candidate(path)
+            return candidates
 
     directories = [root]
     while directories:

--- a/tests/test_privacy_scan.py
+++ b/tests/test_privacy_scan.py
@@ -155,6 +155,19 @@ class PrivacyScanTests(unittest.TestCase):
 
             self.assertIn(("release.txt", "windows-user-path"), scan(root, []))
 
+    def test_scans_explicit_ignored_artifact_directory_inside_git_checkout(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            checkout = Path(tmp)
+            subprocess.run(["git", "init", "-q"], cwd=checkout, check=True)
+            (checkout / ".gitignore").write_text("release-artifacts\n", encoding="utf-8")
+            artifacts = checkout / "release-artifacts"
+            artifacts.mkdir()
+            (artifacts / "SHA256SUMS.txt").write_text(
+                "fixture  rta-smriti-linux-x64\n", encoding="utf-8",
+            )
+
+            self.assertEqual(scan(artifacts, []), [])
+
     def test_git_deleted_paths_are_not_treated_as_release_candidates(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Problem
The tag workflow builds release-artifacts/ inside the checkout, where the directory is intentionally ignored by Git. The privacy scanner used Git enumeration for any nested path inside a repository, so the explicitly selected artifact root appeared empty and every native job failed closed before upload.

## Fix
- use hardened Git enumeration only when the selected scan root is the repository root
- directly and boundedly enumerate an explicit nested artifact root
- preserve symlink, reparse-point, hard-link, special-file, stable-read, archive, byte, file-count, and deadline protections

## Evidence
- failing-then-passing ignored nested artifact regression
- privacy suite: 24 passed, 1 Windows privilege skip
- full suite: 761 passed, 23 skipped, 649 subtests
- repository privacy scan, Gitleaks, Ruff, and diff checks passed
- Codex Security diff scan 581b4365-d71a-4e5a-8fb8-207187a85af9: complete coverage, zero findings

The private local v0.9 design documents remain untracked and are not part of this PR.