### PR TITLE
fix: scan large native release artifacts

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -49,7 +49,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: python scripts/package_release_artifacts.py --include-wheel --sbom release-sbom.cdx.json
       - name: Privacy-scan staged release bundle
-        run: python scripts/privacy_scan.py --root release-artifacts
+        run: python scripts/privacy_scan.py --root release-artifacts --max-file-bytes 134217728
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: ${{ matrix.artifact }}

--- a/scripts/privacy_scan.py
+++ b/scripts/privacy_scan.py
@@ -24,6 +24,7 @@ PATH_PATTERNS = RELEASE_PATH_BYTE_PATTERNS
 FORBIDDEN_SUFFIXES = {".db", ".key", ".log", ".pem", ".sqlite", ".sqlite-shm", ".sqlite-wal"}
 FORBIDDEN_NAMES = {".env"}
 MAX_SCAN_BYTES = 25 * 1024 * 1024
+MAX_CONFIGURABLE_SCAN_BYTES = 128 * 1024 * 1024
 MAX_ARCHIVE_ENTRIES = 10_000
 MAX_ARCHIVE_TOTAL_BYTES = 100 * 1024 * 1024
 MAX_SCAN_FILES = 100_000
@@ -313,7 +314,20 @@ def _scan_archive(
     return findings
 
 
-def scan(root: Path, deny_terms: list[str]) -> list[tuple[str, str]]:
+def scan(
+    root: Path,
+    deny_terms: list[str],
+    *,
+    max_file_bytes: int | None = None,
+) -> list[tuple[str, str]]:
+    scan_file_bytes = MAX_SCAN_BYTES if max_file_bytes is None else max_file_bytes
+    if (
+        isinstance(scan_file_bytes, bool)
+        or not isinstance(scan_file_bytes, int)
+        or scan_file_bytes <= 0
+        or scan_file_bytes > MAX_CONFIGURABLE_SCAN_BYTES
+    ):
+        return [(".", "invalid-max-file-bytes")]
     root = Path(root).expanduser().resolve()
     if not root.exists():
         return [(".", "missing-release-root")]
@@ -355,15 +369,15 @@ def scan(root: Path, deny_terms: list[str]) -> list[tuple[str, str]]:
         if not stat.S_ISREG(metadata.st_mode):
             findings.append((relative, "special-release-file"))
             continue
-        if metadata.st_size > MAX_SCAN_BYTES:
-            findings.append((relative, f"unscanned-file-over-{MAX_SCAN_BYTES}-bytes"))
+        if metadata.st_size > scan_file_bytes:
+            findings.append((relative, f"unscanned-file-over-{scan_file_bytes}-bytes"))
             continue
         budget.raw_bytes += metadata.st_size
         if budget.raw_bytes > MAX_SCAN_TOTAL_BYTES:
             findings.append((".", f"scan-over-{MAX_SCAN_TOTAL_BYTES}-raw-bytes"))
             break
         try:
-            data = stable_file_bytes(path, maximum_bytes=MAX_SCAN_BYTES)
+            data = stable_file_bytes(path, maximum_bytes=scan_file_bytes)
         except (FileNotFoundError, OSError, RuntimeError, ValueError):
             findings.append((relative, "unstable-release-file"))
             continue
@@ -377,9 +391,18 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Scan public-candidate files for credentials, local paths, and private names.")
     parser.add_argument("--deny-term", action="append", default=[], help="Private project, client, or product name that must not appear. Repeat as needed.")
     parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument(
+        "--max-file-bytes",
+        type=int,
+        default=MAX_SCAN_BYTES,
+        help=(
+            "Maximum bytes read from one top-level file. "
+            f"Must be between 1 and {MAX_CONFIGURABLE_SCAN_BYTES}."
+        ),
+    )
     args = parser.parse_args()
     root = args.root.resolve()
-    findings = scan(root, args.deny_term)
+    findings = scan(root, args.deny_term, max_file_bytes=args.max_file_bytes)
     print("privacy scan: completed")
     if findings:
         for path, category in findings:

--- a/tests/test_privacy_scan.py
+++ b/tests/test_privacy_scan.py
@@ -168,6 +168,29 @@ class PrivacyScanTests(unittest.TestCase):
 
             self.assertEqual(scan(artifacts, []), [])
 
+    def test_large_release_binary_requires_an_explicit_bounded_scan_limit(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            private_path = "C:" + r"\Users\Private User\project\proof.txt"
+            payload = b"binary-prefix\x00" + private_path.encode("utf-8")
+            (root / "rta-brain").write_bytes(payload)
+
+            with patch("scripts.privacy_scan.MAX_SCAN_BYTES", 16):
+                default_findings = scan(root, [])
+                release_findings = scan(root, [], max_file_bytes=128)
+
+            self.assertIn(("rta-brain", "unscanned-file-over-16-bytes"), default_findings)
+            self.assertIn(("rta-brain", "windows-user-path"), release_findings)
+
+    def test_large_release_binary_limit_is_hard_bounded(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "rta-brain").write_bytes(b"binary")
+
+            findings = scan(root, [], max_file_bytes=129 * 1024 * 1024)
+
+            self.assertEqual(findings, [(".", "invalid-max-file-bytes")])
+
     def test_git_deleted_paths_are_not_treated_as_release_candidates(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary
- preserve the 25 MiB privacy-scan default
- add an explicit top-level file limit capped at 128 MiB
- scan the generated Linux native binary in full before release upload
- keep archive-member and aggregate anti-expansion limits unchanged

## Verification
- 783 tests passed; 23 platform-specific skips
- privacy suite: 26 passed; 1 expected Windows symlink skip
- repository privacy scan passed
- Gitleaks: 73 commits, no leaks
- actionlint passed
- Ruff passed
- exact Codex Security diff scan 16e25b90-e94f-4e09-bce5-f50253c418ba: complete, zero findings

Private local design documents remain untracked and are not part of this PR.