### PR TITLE
docs: record v0.9.1 publication evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.9.1-alpha] - Unreleased
+## [0.9.1-alpha] - 2026-08-24
 
 - Added progressive authenticated dashboard bootstrap so useful project state renders before deep repository and continuity checks complete.
 - Isolated all project-scoped asynchronous responses so delayed graph, file, capture, retrieval, governance, and truth results cannot leak across project switches.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Rta-Smriti gives each project a memory that stays on your machine.
 ## Latest Release
 
 [`v0.9.1-alpha`](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v0.9.1-alpha)
-is the current patch line. A formal prerelease is accepted only after its exact
+is the current published prerelease. A formal prerelease is accepted only after its exact
 tagged source passes the hosted Windows, macOS, and Ubuntu matrix across Python
 3.11, 3.12, and 3.13. The tag workflow builds and smoke-tests Windows x64, Linux x64, and macOS
 standalone binaries, a universal wheel, CycloneDX SBOMs, and a combined

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-## v0.9.1-alpha Patch Candidate
+## Published v0.9.1-alpha
 
 - Progressive dashboard bootstrap with useful early project state
 - Race-safe isolation across project switching and delayed API responses

--- a/docs/RELEASE_NOTES_v0.9.1-alpha.md
+++ b/docs/RELEASE_NOTES_v0.9.1-alpha.md
@@ -44,9 +44,12 @@ The frozen Windows candidate passed:
   implementation surfaces and 12 of 12 release/website code-bearing surfaces,
   with zero findings in either scan.
 
-The security scan covered this patch, not an independent audit of every
-historical line in the repository. Its temporary local report and private
-operator data are not release artifacts.
+The frozen security scans covered the original operator-readiness and
+release/website surfaces, not an independent audit of every historical line in
+the repository. The later seven-entry concurrency repair was manually reviewed
+and separately passed regression, privacy, secrets, dependency, workflow, and
+patch-integrity checks; it is not misrepresented as part of those frozen scans.
+Temporary local reports and private operator data are not release artifacts.
 
 ## Compatibility And Upgrade
 

--- a/docs/RELEASE_NOTES_v0.9.1-alpha.md
+++ b/docs/RELEASE_NOTES_v0.9.1-alpha.md
@@ -29,7 +29,7 @@ Conceived and researched by Sulabh Dubey. Built with [OpenAI Codex](https://open
 
 The frozen Windows candidate passed:
 
-- 768 Python tests, with 23 explicit platform or optional-capability skips and 649 subtests;
+- 788 Python tests, with 23 explicit platform or optional-capability skips;
 - five dashboard unit tests;
 - four adversarial progressive-loading and project-switch isolation journeys;
 - seven complete rendered operator journeys covering files, graphs, canvas,
@@ -59,13 +59,24 @@ Managed watchers, continuity workers, and capture daemons remain explicit,
 local, opt-in lifecycle services. A stopped service is reported as stopped; the
 dashboard does not silently enable persistent collection.
 
-## Publication Gates
+## Publication Evidence
 
-Hosted CI and release artifacts remain publication gates. Before publication,
-the exact candidate must pass the Windows, macOS, and Linux matrix, installed
-upgrade checks, native binary smoke tests, artifact privacy scans, SBOM
-generation, checksum verification, GitHub Pages QA, and anonymous
-post-publication download verification.
+- PR CI [run 32719412677](https://github.com/sulabhdubey/rta-smriti-brain/actions/runs/32719412677)
+  passed all five Windows, macOS, and Ubuntu jobs.
+- Post-merge CI [run 32722109549](https://github.com/sulabhdubey/rta-smriti-brain/actions/runs/32722109549)
+  passed all five jobs. Its first Windows attempt reached rendered acceptance
+  after all Python and installation checks, then hit runner-level
+  `ERR_NO_BUFFER_SPACE`; one bounded rerun passed the complete job without a
+  code change.
+- Native workflow [run 32724105024](https://github.com/sulabhdubey/rta-smriti-brain/actions/runs/32724105024)
+  built, audited, smoke-tested, packaged, privacy-scanned, and uploaded all
+  Windows, Linux, and macOS artifacts from the exact annotated tag.
+- Pages workflow [run 32722110481](https://github.com/sulabhdubey/rta-smriti-brain/actions/runs/32722110481)
+  deployed the current website. Public desktop and 390 px mobile checks found
+  no console errors, WCAG A/AA violations, broken media, or horizontal overflow.
+- All eight public release files were downloaded without authentication. Every
+  manifested SHA-256 matched; the public Windows binary reported `0.9.1a1`, and
+  the public wheel installed in a clean environment and passed `doctor`.
 
 The existing `v0.9.0-alpha` release notes, screenshots, demo, hashes, and
 verification record remain historical evidence and are not rewritten.

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -1,5 +1,5 @@
 # Release Verification
-## v0.9.1-alpha Candidate Verification
+## Published v0.9.1-alpha Verification
 
 The v0.9.1 patch preserves the published v0.9 architecture and tightens the
 operator surface around progressive loading, project isolation, lifecycle
@@ -8,18 +8,62 @@ status, and explicit multi-project MCP routing.
 | Candidate gate | Result |
 | --- | --- |
 | Package metadata | `0.9.1a1` / `v0.9.1-alpha` |
-| Full local Python regression | 768 passed; 23 explicit platform or optional-capability skips; 649 subtests passed |
+| Full local Python regression | 788 passed; 23 explicit platform or optional-capability skips |
 | Dashboard unit tests | 5 passed |
 | Progressive loading and project-switch isolation | 4 rendered adversarial journeys passed |
 | Complete operator browser suite | 7 rendered journeys passed |
 | Real local multi-project audit | Passed without browser errors, failed API responses, persistent loading states, false integrity alerts, or mobile overflow |
-| Frozen Codex Security diff scans | 13 of 13 changed operator-readiness surfaces and 12 of 12 release/website code-bearing surfaces covered; zero findings |
+| Frozen Codex Security diff scans | 13 of 13 operator-readiness surfaces and 12 of 12 release/website code-bearing surfaces covered; zero findings. The later seven-entry concurrency repair was manually reviewed and separately passed regression, privacy, secrets, dependency, workflow, and patch-integrity checks; it is not misrepresented as part of those frozen scans. |
 | Privacy and secrets | Repository privacy scan and Gitleaks staged/history checks passed |
 | Dependency integrity | npm audit found zero vulnerabilities; Python dependency check found no broken requirements |
 | Patch integrity | `git diff --check` and actionlint passed |
-| Hosted Windows/macOS/Linux CI | Pending exact committed candidate |
-| Native binaries, wheel, SBOMs, and checksums | Pending tag workflow |
-| GitHub Pages and anonymous download acceptance | Pending publication |
+| Hosted Windows/macOS/Linux CI | PR [run 32719412677](https://github.com/sulabhdubey/rta-smriti-brain/actions/runs/32719412677) and post-merge [run 32722109549](https://github.com/sulabhdubey/rta-smriti-brain/actions/runs/32722109549) passed all five jobs |
+| Native binaries, wheel, SBOMs, and checksums | Tag [run 32724105024](https://github.com/sulabhdubey/rta-smriti-brain/actions/runs/32724105024) passed all three platforms |
+| GitHub Pages and anonymous download acceptance | Pages [run 32722110481](https://github.com/sulabhdubey/rta-smriti-brain/actions/runs/32722110481) passed; eight public assets downloaded anonymously and verified |
+
+### Publication State
+
+- Published source commit: `721bd2ec98395f2be36a3b7ebb60c14bfa63c882`
+- Formal annotated tag: `v0.9.1-alpha`
+- Formal prerelease: [Rta-Smriti Brain v0.9.1-alpha](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v0.9.1-alpha)
+- Release classification: alpha prerelease
+- Published assets: three standalone binaries, one universal wheel, three
+  CycloneDX SBOMs, and one combined SHA-256 manifest
+
+The first post-merge Windows attempt passed the complete Python and installed
+package stages, then Chromium reported runner-level `ERR_NO_BUFFER_SPACE` during
+rendered acceptance. One bounded rerun passed the entire Windows job without a
+code change. The retry is recorded here rather than hidden or counted as two
+independent confirmations.
+
+### Public Artifact Acceptance
+
+On 2026-08-24, all eight release files were downloaded from public release URLs
+without authentication. The seven files covered by `SHA256SUMS.txt` matched:
+
+| Artifact | Bytes | SHA-256 |
+| --- | ---: | --- |
+| `rta_smriti_brain-0.9.1a1-py3-none-any.whl` | 498,026 | `eb0d526effd5c3cb836e7ba1b1659b614ad1909830a908a5bc78a7e335d44eb1` |
+| `rta-brain-0.9.1a1-linux-x86_64` | 32,856,192 | `246706ffd0323d2865f8fff7acd76695118518fa7d7969258fdd5b9eab7a2052` |
+| `rta-brain-0.9.1a1-macos-arm64` | 16,856,816 | `b312ea01e20ab6c1ca0657b42e233ed1b02f6b4523b487ac0167597cd3b87e7d` |
+| `rta-brain-0.9.1a1-windows-x86_64.exe` | 18,101,869 | `980a3f4aaaee9de97dca050eb81e4bbcf623c6b13148ef4db572da30af54a323` |
+| Linux CycloneDX SBOM | 1,160 | `21b8144ca4a7998c01309443c13c9b343e74e6794bb05063a08935ef90018a37` |
+| macOS CycloneDX SBOM | 1,164 | `6717dbe8fbca722b6f3132c9f3e818c966b3eb835550f81c108879cce4b02605` |
+| Windows CycloneDX SBOM | 1,165 | `b0d3965fb988c8ae744832bae0dadbccacf45635f1a909586e8b493749624778` |
+
+The combined public manifest itself has SHA-256
+`03a9e40844a47e9a3d643c67d65e9ca701c3853125c613d3ee6b1028f12bcdb4`.
+The anonymously downloaded Windows binary reported `rta-brain 0.9.1a1`. The
+anonymous wheel installed in a clean Python environment with its declared
+dependencies, reported `0.9.1a1`, and returned an `ok` doctor result. The public
+bundle also passed the bounded artifact privacy scan.
+
+### Public Website Acceptance
+
+The deployed website was rendered at 1440 by 900 and 390 by 844. Both views had
+zero horizontal overflow, zero page or console errors, zero WCAG 2.0/2.1 A/AA
+violations, loaded all images, and loaded the 60.053-second product video. The
+release page, installation document, and website URLs all resolved publicly.
 
 The real-project audit used private local brains only as operator fixtures.
 Project names, roots, database contents, capability tokens, and local scan paths

--- a/launch-assets/press/PRODUCT_FACT_SHEET.md
+++ b/launch-assets/press/PRODUCT_FACT_SHEET.md
@@ -4,7 +4,7 @@
 
 **Current prerelease:** [`v0.9.1-alpha`](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v0.9.1-alpha)
 
-**Release contract:** The alpha patch adds progressive operator loading and race-safe multi-project isolation. Formal publication requires SHA-256 checksums, a universal wheel, CycloneDX SBOMs, and standalone Windows, Linux, and macOS artifacts.
+**Published release:** The alpha patch adds progressive operator loading and race-safe multi-project isolation. Its public bundle includes SHA-256 checksums, a universal wheel, CycloneDX SBOMs, and standalone Windows, Linux, and macOS artifacts verified from the annotated tag.
 
 **Creation:** Conceived and researched by Sulabh Dubey; built with [OpenAI Codex](https://openai.com/codex/) as the primary AI engineering agent under maintainer review. See [`CONTRIBUTORS.md`](../../CONTRIBUTORS.md).
 

--- a/launch-site/index.html
+++ b/launch-site/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#050a10" />
-    <meta name="description" content="Rta-Smriti v0.9 is a local continuity system with Universal Capture, bitemporal project truth, and governed context for AI coding agents." />
+    <meta name="description" content="Rta-Smriti v0.9.1-alpha is a local continuity system with operator-ready Universal Capture, bitemporal project truth, and governed context for AI coding agents." />
     <meta property="og:title" content="Rta-Smriti Brain" />
     <meta property="og:description" content="Universal Capture, bitemporal project truth, and governed context compilation for AI coding agents." />
     <meta property="og:type" content="website" />
@@ -13,7 +13,7 @@
     <meta property="og:image" content="./assets/github-social-preview-v0.9.png" />
     <meta name="twitter:card" content="summary_large_image" />
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
-    <title>Rta-Smriti Brain v0.9 — Governed continuity for AI coding agents</title>
+    <title>Rta-Smriti Brain v0.9.1-alpha — Governed continuity for AI coding agents</title>
   </head>
   <body>
     <div id="root"></div>

--- a/launch-site/src/main.jsx
+++ b/launch-site/src/main.jsx
@@ -132,7 +132,7 @@ function Header() {
       <div className="shell headerInner">
         <Brand />
         <nav className={open ? "siteNav open" : "siteNav"} aria-label="Main navigation">
-          <a href="#release" onClick={() => setOpen(false)}>v0.9</a>
+          <a href="#release" onClick={() => setOpen(false)}>v0.9.1</a>
           <a href="#product" onClick={() => setOpen(false)}>Product</a>
           <a href="#architecture" onClick={() => setOpen(false)}>Architecture</a>
           <a href="#difference" onClick={() => setOpen(false)}>Why different</a>
@@ -332,13 +332,13 @@ function ReleaseStory() {
     ["v0.6", "Hardened runtime", "Cross-platform lifecycle, parsing, hybrid retrieval, signed and encrypted snapshots."],
     ["v0.7", "Temporal truth", "Append-only event sourcing with recorded time, valid time, claims, evidence, and contradictions."],
     ["v0.8", "Context compiler", "Capability-bound, privacy-aware packs with fixed-point scoring, receipts, and abstention."],
-    ["v0.9", "Universal Capture", "Opt-in adapters, bounded private spool, normalization, replay, retention, deletion, and diagnostics."],
+    ["v0.9.1", "Operator-ready Universal Capture", "Progressive multi-project loading, race-safe project isolation, bounded capture diagnostics, and verified cross-platform artifacts."],
   ];
   return (
     <section className="releaseStory" id="release">
       <div className="shell">
         <div className="sectionHeading rowHeading">
-          <div><span className="sectionIndex">02 / CURRENT RELEASE</span><h2>v0.9 is a continuity system, not a chat transcript dump.</h2></div>
+          <div><span className="sectionIndex">02 / CURRENT RELEASE</span><h2>v0.9.1 makes governed continuity dependable under real multi-project load.</h2></div>
           <p>The newest layer captures activity conservatively, keeps it untrusted, and routes only governed evidence into the next agent task.</p>
         </div>
         <div className="releaseTrack">

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -28,6 +28,9 @@ class ReleaseMetadataTests(unittest.TestCase):
         release_notes = (ROOT / "docs" / "RELEASE_NOTES_v0.9.1-alpha.md").read_text(
             encoding="utf-8"
         )
+        release_verification = (ROOT / "docs" / "RELEASE_VERIFICATION.md").read_text(
+            encoding="utf-8"
+        )
 
         self.assertEqual(__version__, EXPECTED_PYTHON_VERSION)
         self.assertEqual(pyproject["project"]["version"], EXPECTED_PYTHON_VERSION)
@@ -38,17 +41,24 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertIn("v0.9.1 Alpha Operator Console", dashboard)
         self.assertIn("version: 0.9.1-alpha", citation)
         self.assertIn("## Published v0.9.0-alpha", roadmap)
-        self.assertIn("## v0.9.1-alpha Patch Candidate", roadmap)
-        self.assertIn("## [0.9.1-alpha] - Unreleased", changelog)
+        self.assertIn("## Published v0.9.1-alpha", roadmap)
+        self.assertIn("## [0.9.1-alpha] - 2026-08-24", changelog)
         self.assertIn("## [0.9.0-alpha] - 2026-08-23", changelog)
         self.assertIn("**Current prerelease:** [`v0.9.1-alpha`]", fact_sheet)
+        self.assertIn("**Published release:**", fact_sheet)
+        self.assertNotIn("Formal publication requires", fact_sheet)
         self.assertIn("/releases/tag/v0.9.1-alpha", readme)
         self.assertNotIn("uncommitted `v0.9.1-alpha`", readme)
         self.assertIn("capture           Operate the governed universal capture journal", readme)
         self.assertNotIn("uncommitted local candidate", release_notes)
         self.assertIn("13 of 13 operator-readiness", release_notes)
         self.assertIn("12 of 12 release/website code-bearing surfaces", release_notes)
-        self.assertIn("Hosted CI and release artifacts remain publication gates", release_notes)
+        self.assertIn("## Publication Evidence", release_notes)
+        self.assertIn("run 32724105024", release_notes)
+        self.assertIn("downloaded without authentication", release_notes)
+        self.assertIn("## Published v0.9.1-alpha Verification", release_verification)
+        self.assertIn("Formal annotated tag: `v0.9.1-alpha`", release_verification)
+        self.assertIn("03a9e40844a47e9a3d643c67d65e9ca701c3853125c613d3ee6b1028f12bcdb4", release_verification)
         self.assertIn("Conceived and researched by [Sulabh Dubey]", readme)
         self.assertIn("[OpenAI Codex](https://openai.com/codex/)", readme)
         self.assertIn("Rta-Smriti Brain was conceived, researched, and product-directed", contributors)


### PR DESCRIPTION
## Summary
- replace candidate placeholders with exact v0.9.1 CI, artifact, Pages, and anonymous-install evidence
- record public asset sizes and SHA-256 values, including the bounded Windows runner retry
- align launch-site version labels and metadata with v0.9.1-alpha

## Verification
- npm run build:launch
- npm run test:launch
- python scripts/privacy_scan.py
- gitleaks dir --redact --no-banner --exit-code 1 .
- actionlint
- npm audit --audit-level=high
- git diff --check