### PR TITLE
Open community feedback and contribution paths

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Installation help and questions
+    url: https://github.com/sulabhdubey/rta-smriti-brain/discussions/categories/q-a
+    about: Ask for help without opening a formal bug report.
+  - name: Ideas and design proposals
+    url: https://github.com/sulabhdubey/rta-smriti-brain/discussions/categories/ideas
+    about: Discuss a broad idea before investing in an implementation.
+  - name: Private security report
+    url: https://github.com/sulabhdubey/rta-smriti-brain/security/advisories/new
+    about: Report vulnerabilities privately. Do not publish secrets or exploit details.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,46 @@
 # Contributing
 
-Rta-Smriti Brain is intentionally dependency-light. Keep changes local-first, test-first, and inspectable.
+Rta-Smriti Brain is intentionally local-first, dependency-light, and inspectable. Small, well-tested contributions are welcome.
+
+## Choose A Starting Point
+
+- Browse [`good first issue`](https://github.com/sulabhdubey/rta-smriti-brain/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) for bounded tasks with acceptance criteria.
+- Browse [`help wanted`](https://github.com/sulabhdubey/rta-smriti-brain/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) for larger tasks where maintainer context is available.
+- Ask an installation or design question in [Q&A](https://github.com/sulabhdubey/rta-smriti-brain/discussions/categories/q-a).
+- Propose an idea in [Ideas](https://github.com/sulabhdubey/rta-smriti-brain/discussions/categories/ideas) before building a broad feature.
+
+Comment on the issue you want to take before starting. That prevents duplicate work and gives us a chance to confirm the boundary.
+
+## A 15-Minute First Contribution
+
+Documentation, synthetic fixtures, and focused regression tests are good first contributions:
+
+1. Fork the repository and create a short-lived branch.
+2. Make one focused change tied to an open issue.
+3. Add or update the smallest test that proves the change.
+4. Run the focused test and the privacy test.
+5. Open a pull request using the repository template.
+
+Do not include a real brain database, context pack, transcript, local path, credential, or private project excerpt. Use the synthetic fixtures under `tests/fixtures/` and `rta_brain/data/`.
 
 ## Development
 
-Run tests:
+Create a Python 3.11+ virtual environment and install the project:
 
 ```powershell
+python -m venv .venv
+& .\.venv\Scripts\python.exe -m pip install -e .
+```
+
+```bash
+python3 -m venv .venv
+./.venv/bin/python -m pip install -e .
+```
+
+Run the focused test first, then the full Python suite:
+
+```powershell
+python -m unittest tests.test_community_health -v
 python -m unittest discover -s tests -v
 ```
 
@@ -24,6 +58,15 @@ npm run build
 npm run build:launch
 ```
 
+Dashboard behavior changes also require the rendered operator suite:
+
+```powershell
+npx playwright install chromium
+npm run test:operator
+```
+
+See [Operator QA](docs/OPERATOR_QA.md) for the browser acceptance boundary.
+
 ## Design Rules
 
 - Prefer deterministic retrieval and explicit provenance over opaque automation.
@@ -32,6 +75,22 @@ npm run build:launch
 - Do not store secrets.
 - Add tests before behavior changes.
 - Keep MCP tools narrow and composable.
+
+## Pull Request Scope
+
+- Keep each pull request tied to one issue or one coherent outcome.
+- Explain the operator problem, the behavior change, and the evidence in the pull-request body.
+- Add tests for changed behavior and update user-facing documentation when commands or workflows change.
+- Preserve cross-platform behavior on Windows, macOS, and Linux.
+- Avoid unrelated formatting, generated-asset, dependency, or metadata churn.
+
+The maintainer target is to acknowledge a focused pull request within three business days. This is an alpha community project, so complex reviews may take longer; review status will be communicated on the pull request.
+
+## Questions And Security
+
+Use [GitHub Discussions](https://github.com/sulabhdubey/rta-smriti-brain/discussions) for installation help, design questions, and early ideas. Use an issue for a reproducible public bug.
+
+Do not open a public issue for a vulnerability or include exploit details in Discussions. Follow [SECURITY.md](SECURITY.md) and use [private vulnerability reporting](https://github.com/sulabhdubey/rta-smriti-brain/security/advisories/new).
 
 ## Release Checklist
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ BrainDir="$HOME/.local/share/rta-smriti/brains"
 "$RtaBrain" start /path/to/my-project --project my-project --brain-dir "$BrainDir" --write-agents
 ```
 
+### Share What Happened
+
+Tried Rta-Smriti on a real project? [Share your experience in Discussions](https://github.com/sulabhdubey/rta-smriti-brain/discussions), [ask for installation help](https://github.com/sulabhdubey/rta-smriti-brain/discussions/categories/q-a), or [pick a first contribution](https://github.com/sulabhdubey/rta-smriti-brain/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22). If it saved you from repeating project context, consider [starring the repository](https://github.com/sulabhdubey/rta-smriti-brain).
+
 Verify that commands are operating on the intended checkout by passing its root:
 
 ```powershell

--- a/tests/test_community_health.py
+++ b/tests/test_community_health.py
@@ -1,0 +1,40 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class CommunityHealthTests(unittest.TestCase):
+    def test_readme_invites_feedback_and_first_contributions(self):
+        readme = (ROOT / "README.md").read_text(encoding="utf-8")
+
+        self.assertIn("### Share What Happened", readme)
+        self.assertIn("/discussions/categories/q-a", readme)
+        self.assertIn('label%3A%22good+first+issue%22', readme)
+
+    def test_contributing_has_a_bounded_first_contribution_path(self):
+        contributing = (ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
+
+        self.assertIn("## A 15-Minute First Contribution", contributing)
+        self.assertIn("## Pull Request Scope", contributing)
+        self.assertIn("private vulnerability reporting", contributing)
+
+    def test_issue_router_uses_discussions_and_private_security_reporting(self):
+        config = (
+            ROOT / ".github" / "ISSUE_TEMPLATE" / "config.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("blank_issues_enabled: false", config)
+        self.assertIn(
+            "https://github.com/sulabhdubey/rta-smriti-brain/discussions/categories/q-a",
+            config,
+        )
+        self.assertIn(
+            "https://github.com/sulabhdubey/rta-smriti-brain/security/advisories/new",
+            config,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- enable a visible README path from first run to Discussions, installation help, starter issues, and starring
- add a 15-minute contributor path, review expectations, and private security routing
- add a GitHub issue router and regression tests for community health

## Public community setup

- Discussions enabled
- three starter discussions published
- six scoped starter issues published with `good first issue` or `help wanted`

## Verification

- `python -m unittest tests.test_community_health -v`: 3 passed
- `python -m unittest tests.test_privacy_scan -v`: 25 passed, 1 Windows symlink skip
- full Python suite: 788 passed, 23 platform skips; 3 nested-worktree ACL failures rerun in the top-level checkout as 7 passed, 1 Windows symlink skip
- `python -m compileall -q rta_brain tests scripts`: passed
- `actionlint`: passed for all workflows
- `gitleaks detect --source . --no-banner --redact --exit-code 1`: no leaks across 85 commits
- `python scripts/privacy_scan.py`: passed
- `npm audit --audit-level=high`: 0 vulnerabilities
- `git diff --cached --check`: passed

No private brain databases, context packs, transcripts, local project excerpts, credentials, or local paths are included.