### PR TITLE
docs: add Zed MCP host recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,8 @@ Continuity capture uses a 30-day session lookback on first start so a new brain 
 Rta-Smriti ships a stdio MCP server. Run `mcp-config` as shown above to generate
 the correct absolute `command` and `args` for the current operating system and
 Python environment; do not hand-edit a Windows path into a macOS or Linux host.
+For a host-specific walkthrough, see the community
+[Zed setup recipe](docs/MCP_HOST_ZED.md).
 
 The generated server is project-bound and read-only by default. Memory writes,
 canonical-repository ingestion, and thread ingestion require explicit startup

--- a/docs/MCP_HOST_ZED.md
+++ b/docs/MCP_HOST_ZED.md
@@ -5,8 +5,8 @@ is not an official integration or partnership with Zed Industries.
 
 The recipe was validated on Windows 11 with Zed 1.16.2. The generated command
 was probed through MCP initialize, `tools/list`, and ping with `mcp-doctor`.
-Zed's documented `context_servers` format and server-status screen were used as
-the host-side contract.
+Zed's documented `context_servers` format and server-status guidance were used
+as the host-side contract.
 
 ## Before editing Zed settings
 
@@ -78,4 +78,3 @@ Zed's current MCP configuration and status guidance is maintained in the
 [official Zed MCP documentation](https://zed.dev/docs/ai/mcp). Its
 [worktree-trust documentation](https://zed.dev/docs/worktree-trust) explains
 how project-local MCP settings are gated.
-

--- a/docs/MCP_HOST_ZED.md
+++ b/docs/MCP_HOST_ZED.md
@@ -1,0 +1,81 @@
+# Connect Rta-Smriti to Zed
+
+This community recipe connects Rta-Smriti's local stdio MCP server to Zed. It
+is not an official integration or partnership with Zed Industries.
+
+The recipe was validated on Windows 11 with Zed 1.16.2. The generated command
+was probed through MCP initialize, `tools/list`, and ping with `mcp-doctor`.
+Zed's documented `context_servers` format and server-status screen were used as
+the host-side contract.
+
+## Before editing Zed settings
+
+Generate the configuration from the installed Rta-Smriti command. Do not copy
+paths from another machine or write the command by hand.
+
+For one project:
+
+```powershell
+& $RtaBrain --db "$BrainDir\project-name.sqlite" --json mcp-config --project project-name --name rta-smriti-project
+& $RtaBrain --db "$BrainDir\project-name.sqlite" --json mcp-doctor --project project-name
+```
+
+For a read-only gateway across the project databases in one brain directory:
+
+```powershell
+& $RtaBrain --json mcp-config --brain-dir $BrainDir --name rta-smriti
+```
+
+Both forms are read-only by default. Do not add any `--allow-*` capability
+unless you have reviewed and intend to grant it. For the single-project form,
+continue only when `mcp-doctor` returns `"ready": true`. The multi-project form
+routes by project name and fails closed when a name is ambiguous.
+
+## Add the local server
+
+Open **Settings > AI > MCP Servers**, select **Add Server > Add Local Server**,
+then open the settings file with `zed: open settings file`. Zed stores custom
+local servers under `context_servers`, while Rta-Smriti emits the portable
+`mcpServers` shape used by many hosts.
+
+Copy only the generated server entry and place it under `context_servers`:
+
+```json
+{
+  "context_servers": {
+    "rta-smriti-project": {
+      "command": "<copy the generated command exactly>",
+      "args": ["<copy every generated argument in order>"],
+      "env": {}
+    }
+  }
+}
+```
+
+Do not commit generated absolute paths. If you put a single-project entry in
+`.zed/settings.json`, keep that local file out of version control, inspect it
+before trusting the worktree, and use Zed's worktree trust prompt deliberately.
+Use the user settings file for a multi-project gateway that should be available
+across trusted worktrees.
+
+Fully restart Zed after saving the entry and create a new Agent task. Existing
+tasks do not acquire newly registered MCP tools. Return to **Settings > AI > MCP
+Servers** and confirm that the indicator beside the server is green with the
+tooltip **Server is active**. In the new task, ask Zed to list the Rta-Smriti
+tools or explicitly mention the configured server name.
+
+If the server is not active:
+
+1. Run `mcp-doctor` again and require `"ready": true`.
+2. Compare Zed's `command` and `args` with the newly generated entry; preserve
+   every absolute path and argument boundary.
+3. Confirm that the selected database, project root, and checkout have not
+   moved. Regenerate the entry after an intentional rebind.
+4. Check that the worktree is trusted when using `.zed/settings.json`.
+5. Restart Zed completely and open another new Agent task.
+
+Zed's current MCP configuration and status guidance is maintained in the
+[official Zed MCP documentation](https://zed.dev/docs/ai/mcp). Its
+[worktree-trust documentation](https://zed.dev/docs/worktree-trust) explains
+how project-local MCP settings are gated.
+

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -271,6 +271,10 @@ A `ready` result proves initialize, tools/list, and ping worked for that command
 Copy the returned config into the host, then start a fresh agent task. Existing
 tasks cannot dynamically acquire newly registered MCP tools.
 
+Zed users can follow the focused [Zed MCP host recipe](MCP_HOST_ZED.md) for the
+`context_servers` mapping, single-project and read-only multi-project placement,
+worktree trust, restart, and server-status checks.
+
 Governed context compilation is a narrower, fail-closed delegation. After the
 operator authorizes a task contract, append its exact positive ID and SHA-256
 digest to a **single-project** server's generated `args`:

--- a/tests/test_community_health.py
+++ b/tests/test_community_health.py
@@ -35,6 +35,19 @@ class CommunityHealthTests(unittest.TestCase):
             config,
         )
 
+    def test_zed_recipe_is_linked_and_keeps_generated_config_read_only(self):
+        readme = (ROOT / "README.md").read_text(encoding="utf-8")
+        usage = (ROOT / "docs" / "USAGE_GUIDE.md").read_text(encoding="utf-8")
+        recipe = (ROOT / "docs" / "MCP_HOST_ZED.md").read_text(encoding="utf-8")
+
+        self.assertIn("docs/MCP_HOST_ZED.md", readme)
+        self.assertIn("MCP_HOST_ZED.md", usage)
+        self.assertIn('"context_servers"', recipe)
+        self.assertIn("mcp-doctor", recipe)
+        self.assertIn("read-only by default", recipe)
+        self.assertIn("create a new Agent task", recipe)
+        self.assertIn("not an official integration or partnership", recipe)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- add a focused Zed MCP host recipe for both a project-bound server and the read-only multi-project gateway
- map the generated `mcpServers` entry into Zed's documented `context_servers` shape without hardcoding private paths
- cover worktree trust, full restart/new-task behavior, active-server verification, and troubleshooting
- link the recipe from the README and usage guide with a small documentation regression test

## Validation

- `python -m unittest tests.test_community_health` (4 passed)
- `python -m compileall -q rta_brain tests`
- Windows 11 with Zed 1.16.2 installed from the official package
- generated a project-bound configuration and ran `mcp-doctor`: ready, 24 tools, initialize/tools-list/ping passed

The host-side settings shape and active-server check follow Zed's official documentation. This validation did not modify personal Zed settings or claim an official Zed partnership.

Closes #18
