### PR TITLE
docs: seal v1 release verification

### DIFF
--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -1,10 +1,11 @@
 # Release Verification
 
-## v1.0.0-alpha Release Qualification
+## Published v1.0.0-alpha Verification
 
-This section records the frozen `1.0.0a1` source qualification before the
-annotated tag and release assets are created. Publication-only fields are
-updated from immutable GitHub evidence after those gates complete.
+This section records the frozen source, hosted compatibility, immutable tag
+build, public artifacts, and anonymous-download acceptance for `v1.0.0-alpha`.
+It does not treat source tests as artifact proof or a clone as a verified
+installation.
 
 | Release gate | Current evidence |
 | --- | --- |
@@ -14,16 +15,51 @@ updated from immutable GitHub evidence after those gates complete.
 | Rendered operator acceptance | `8` Playwright operator journeys passed; launch desktop/mobile, interaction, media, link, and accessibility QA passed |
 | Synthetic benchmark | Lexical/hash hybrid Recall@K, MRR, and nDCG were `1.0`; cognition gates were `1.0`; governed continuation was `1.0` against the packaged historical baseline of `0.25`. This is synthetic regression evidence, not a market-superiority claim |
 | 10,000-source performance | First index `233.56 s`; cached deep freshness `2.427 s`; cognition median `25.7 ms`, p95 `28.089 ms`; context-pack p95 `271.037 ms`; search p95 `258.849 ms` |
-| Privacy and security | Exact public-diff privacy and Gitleaks scans passed; 92-commit Gitleaks history scan passed; npm and Python dependency audits found no known vulnerabilities; actionlint passed; sealed Codex Security scan `8ab0e2aa-a366-4c4a-b60c-8fbccd36e7e2` completed eight surfaces with zero findings |
+| Privacy and security | Exact public-diff privacy and Gitleaks scans passed; a 99-commit Gitleaks history scan passed; npm and Python dependency audits found no known vulnerabilities; actionlint passed; sealed Codex Security scan `8ab0e2aa-a366-4c4a-b60c-8fbccd36e7e2` completed eight surfaces with zero findings |
 | Installed package/native Windows | Clean upgrade `0.9.1a1` to `1.0.0a1` and uninstall passed; Windows standalone CLI, SQLite/FTS, MCP, benchmark, Tree-sitter, capture, encrypted and Ed25519 snapshots, background sync, and managed-console smoke passed |
 | Live daemon and MCP dogfood | Continuity daemon captured the active task with zero new errors; the generated MCP configuration negotiated successfully, exposed `29` tools, and reported server `1.0.0a1` ready |
-| Hosted Windows/macOS/Linux CI | PR [run 32876149143](https://github.com/sulabhdubey/rta-smriti-brain/actions/runs/32876149143) and merged-source [run 32877526107](https://github.com/sulabhdubey/rta-smriti-brain/actions/runs/32877526107) passed all five jobs |
-| Tagged binaries, wheel, SBOMs, checksums | Pending the approved `v1.0.0-alpha` tag workflow |
-| Anonymous download acceptance | Pending formal publication |
+| Hosted Windows/macOS/Linux CI | Final repair PR [run 32892589775](https://github.com/sulabhdubey/rta-smriti-brain/actions/runs/32892589775) and final `main` [run 32894041608](https://github.com/sulabhdubey/rta-smriti-brain/actions/runs/32894041608) passed all five jobs |
+| Native preflight and tag build | Final-main preflight [run 32895430079](https://github.com/sulabhdubey/rta-smriti-brain/actions/runs/32895430079) and immutable-tag [run 32895977890](https://github.com/sulabhdubey/rta-smriti-brain/actions/runs/32895977890) passed Windows, macOS, and Linux |
+| GitHub Pages | v1 launch-site [run 32889833838](https://github.com/sulabhdubey/rta-smriti-brain/actions/runs/32889833838) passed; the later operator-console race repair did not change Pages inputs |
+| Anonymous download acceptance | All eight public files downloaded without authentication; the seven payload files matched the published SHA-256 manifest |
 
-The release tag, GitHub prerelease, tagged native artifacts, published
-checksums/SBOMs, and anonymous-download acceptance are not inferred from the
-source qualification. They are recorded only after their public workflows pass.
+### Publication State
+
+- Published source commit: `a1b05022aff6df3a066ae5abcad3877f6407eafb`
+- Formal annotated tag: `v1.0.0-alpha`
+- Formal prerelease: [Rta-Smriti Brain v1.0.0-alpha](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v1.0.0-alpha)
+- Release classification: alpha prerelease
+- Published assets: three standalone binaries, one universal wheel, three
+  CycloneDX SBOMs, and one combined SHA-256 manifest
+
+### Public Artifact Acceptance
+
+On 2026-08-26, all eight release files were downloaded from public GitHub URLs
+without authentication. The seven files covered by `SHA256SUMS.txt` matched:
+
+| Artifact | Bytes | SHA-256 |
+| --- | ---: | --- |
+| `rta_smriti_brain-1.0.0a1-py3-none-any.whl` | 526,856 | `16d1a1c14cbf736c02bc5920f03d186e279095c1855196e1dae086726534e03f` |
+| `rta-brain-1.0.0a1-linux-x86_64` | 32,916,960 | `0e74fe2ef369e4230688ecd1925ea6cc8d59f57fa2cfa99af3e0afe4d692cb29` |
+| `rta-brain-1.0.0a1-macos-arm64` | 16,913,136 | `a0ce50e3b723eaef1b4f2188b82fed31f2b7976721396700f2bd22c52188dbad` |
+| `rta-brain-1.0.0a1-windows-x86_64.exe` | 18,157,373 | `c3dfde9834c7dcbf8c01febe39bcee1f29702c625747968262971a30e258b800` |
+| Linux CycloneDX SBOM | 1,162 | `3947a65ffea16a7d5ee315a785c06461ee63bde1b9a8e5c360066d76f34cf815` |
+| macOS CycloneDX SBOM | 1,154 | `30928e09b6130c23b7459fd026e6e2df3b26ac0e840e369d78826f8fc7e7736b` |
+| Windows CycloneDX SBOM | 1,165 | `6c834b5e4b5f690093a5072981eb2a10a639b94e102d029baa0da488096cd923` |
+
+The combined public manifest has SHA-256
+`f86c5e197debe71dcf23dfc636c7fb49e2d7186db2ae549d9e6d425618b41376`.
+The anonymously downloaded Windows binary reported `rta-brain 1.0.0a1`. The
+anonymous wheel installed in a second clean Python environment with its
+declared dependencies and reported `1.0.0a1`.
+
+Before publication, the same wheel bytes were exercised end to end against an
+isolated project: initialization, indexing, provenance-bearing memory,
+structured checkpointing, cached deep SHA-256 freshness, focused context-pack
+generation, continuity start/status/stop, and operational readiness passed. A
+brain under a shared Windows temporary ACL was rejected fail-closed; the flow
+passed after using a dedicated owner-only brain directory.
+
 ## Published v0.9.1-alpha Verification
 
 The v0.9.1 patch preserves the published v0.9 architecture and tightens the

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -62,8 +62,11 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertIn("## Stable Interfaces", architecture)
         self.assertIn("Alpha prerelease", release_notes)
         self.assertIn("817` Python tests", release_notes)
-        self.assertIn("## v1.0.0-alpha Release Qualification", release_verification)
-        self.assertIn("Pending the approved `v1.0.0-alpha` tag workflow", release_verification)
+        self.assertIn("## Published v1.0.0-alpha Verification", release_verification)
+        self.assertIn("a1b05022aff6df3a066ae5abcad3877f6407eafb", release_verification)
+        self.assertIn("/releases/tag/v1.0.0-alpha", release_verification)
+        self.assertNotIn("Pending the approved `v1.0.0-alpha` tag workflow", release_verification)
+        self.assertNotIn("Pending formal publication", release_verification)
         self.assertIn("# v1 Project Cognition Threat Model", threat_model)
 
         self.assertIn("Conceived and researched by [Sulabh Dubey]", readme)


### PR DESCRIPTION
## Summary
- replace pre-publication v1 qualification placeholders with immutable public evidence
- record final source SHA, hosted CI, native tag build, public checksums, and anonymous acceptance
- update metadata tests to reject stale publication placeholders

## Verification
- 25 focused release tests passed; 1 intentional skip
- exact two-file privacy scan passed
- exact two-file Gitleaks scan passed
- git diff --check passed
- live Pages bundle and formal prerelease verified publicly