### PR TITLE
fix: close truth state before response

### DIFF
--- a/rta_brain/console.py
+++ b/rta_brain/console.py
@@ -1151,9 +1151,9 @@ def make_handler(config: ConsoleConfig):
                             result = verify_ledger(conn, project=q["project"])
                         else:
                             raise ValueError(f"unsupported truth query mode: {mode}")
-                        self._json(redact_truth_for_operator(result))
                     finally:
                         conn.close()
+                    self._json(redact_truth_for_operator(result))
                     return
                 if parsed.path == "/api/capture":
                     q = _query(self)
@@ -1525,9 +1525,9 @@ def make_handler(config: ConsoleConfig):
                             )
                         else:
                             raise ValueError(f"unsupported truth action: {action}")
-                        self._json(redact_truth_for_operator(result))
                     finally:
                         conn.close()
+                    self._json(redact_truth_for_operator(result))
                     return
                 if self.path == "/api/memory":
                     conn = _open_db(resolve_brain_db(config, payload["db_path"]))


### PR DESCRIPTION
## Root cause
A temporal-truth mutation could return its HTTP body before the SQLite connection closed. A fast follow-up history request could overlap cleanup and return an intermittent 500 on macOS.

## Fix
- close temporal-truth GET and POST database connections before emitting JSON
- preserve the established response payload and error boundary

## Verification
- focused live request path: 20/20 consecutive passes
- managed console: 29 passed, 1 intentional skip
- temporal/console regression: 63 passed, 2 subtests
- release metadata/artifacts: 6 passed
- exact one-file compile, privacy, Gitleaks, and diff checks passed