### PR TITLE
docs: publish v1.0.3 release evidence

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ type: software
 authors:
   - family-names: Dubey
     given-names: Sulabh
-version: 1.0.2-alpha
+version: 1.0.3-alpha
 license: MIT
 abstract: "Local-first project memory, repository graph, context packs, and MCP tools for AI coding agents. Conceived and researched by Sulabh Dubey; built with OpenAI Codex as the primary AI engineering agent under maintainer review."
 repository-code: "https://github.com/sulabhdubey/rta-smriti-brain"

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Rta-Smriti Brain
 
-## v1.0.2-alpha
+## v1.0.3-alpha
 
-`v1.0.2-alpha` is the current operator-hardening prerelease for the v1 release
-line. It adds hidden Windows login startup, one shared terminal-independent
-worker launcher, Watchdog-by-default event sync, adaptive large-repository
-polling fallback, idempotent Windows private-directory onboarding, and a WCAG AA
-contrast correction. See the [release notes](docs/RELEASE_NOTES_v1.0.2-alpha.md)
+`v1.0.3-alpha` is the current maintenance prerelease for the v1 release line.
+It replaces misleading empty-brain rendering after an expired console
+capability with a direct recovery path, and turns newer-schema launcher failures
+into actionable, non-mutating upgrade guidance. See the
+[release notes](docs/RELEASE_NOTES_v1.0.3-alpha.md)
 and bounded [verification ledger](docs/RELEASE_VERIFICATION.md).
 
 v1 turns the brain from a searchable index into an inspectable project-reality
@@ -22,13 +22,13 @@ work, route models, or replace an agent harness.
 [![Release](https://img.shields.io/github/v/release/sulabhdubey/rta-smriti-brain?include_prereleases&label=release)](https://github.com/sulabhdubey/rta-smriti-brain/releases)
 [![License: MIT](https://img.shields.io/badge/license-MIT-2ea44f.svg)](LICENSE)
 
-**A sovereign local project-memory and evidence layer for AI coding agents. The `v1.0.2-alpha` release preserves deterministic Project Reality while hardening Windows onboarding, invisible background lifecycle, large-repository sync, and dashboard accessibility.**
+**A sovereign local project-memory and evidence layer for AI coding agents. The `v1.0.3-alpha` release preserves deterministic Project Reality while hardening authorization recovery, launcher upgrades, and schema-compatibility diagnostics.**
 
 **Build provenance:** Conceived and researched by [Sulabh Dubey](https://github.com/sulabhdubey). Built with [OpenAI Codex](https://openai.com/codex/) as the primary design, engineering, testing, and documentation agent under Sulabh's product direction and release approval. [Details](CONTRIBUTORS.md).
 
 Rta-Smriti now connects repository intelligence, durable decisions, agent-session continuity, and evidence-aware retrieval through a private local event journal. Capture is opt-in, bounded, redacted before durable queuing, and explicitly treated as untrusted evidence until an operator or verifier promotes a claim.
 
-[Current release: v1.0.2-alpha](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v1.0.2-alpha) · [Release notes](docs/RELEASE_NOTES_v1.0.2-alpha.md) · [Live website](https://sulabhdubey.github.io/rta-smriti-brain/) · [60-second v1.0.2 product demo](launch-assets/product-hunt/rta-smriti-v1.0.2-product-demo.mp4) · [Installation](docs/INSTALLATION.md) · [Usage guide](docs/USAGE_GUIDE.md) · [Architecture](docs/ARCHITECTURE.md) · [Public benchmark](docs/PUBLIC_BENCHMARK.md) · [Release verification](docs/RELEASE_VERIFICATION.md) · [Build provenance](CONTRIBUTORS.md) · [Security](SECURITY.md) · [Roadmap](ROADMAP.md)
+[Current release: v1.0.3-alpha](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v1.0.3-alpha) · [Release notes](docs/RELEASE_NOTES_v1.0.3-alpha.md) · [Live website](https://sulabhdubey.github.io/rta-smriti-brain/) · [60-second v1 product demo (captured from v1.0.2)](launch-assets/product-hunt/rta-smriti-v1.0.2-product-demo.mp4) · [Installation](docs/INSTALLATION.md) · [Usage guide](docs/USAGE_GUIDE.md) · [Architecture](docs/ARCHITECTURE.md) · [Public benchmark](docs/PUBLIC_BENCHMARK.md) · [Release verification](docs/RELEASE_VERIFICATION.md) · [Build provenance](CONTRIBUTORS.md) · [Security](SECURITY.md) · [Roadmap](ROADMAP.md)
 
 Rta-Smriti Brain turns a project repository, long agent threads, durable decisions, and evidence into a small local memory graph that Codex, Claude Code, Cursor, or any MCP-capable agent can reuse before doing work.
 
@@ -40,13 +40,15 @@ Rta-Smriti gives each project a memory that stays on your machine.
 
 ## Latest Release
 
-[`v1.0.2-alpha`](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v1.0.2-alpha)
+[`v1.0.3-alpha`](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v1.0.3-alpha)
 is the current published prerelease. The exact tagged source passes the hosted
 Windows, macOS, and Ubuntu matrix across Python 3.11, 3.12, and 3.13. The native
 workflow builds and smoke-tests Windows x64, Linux x64, and macOS standalone
 binaries, a universal wheel, CycloneDX SBOMs, and a combined
-`SHA256SUMS.txt`; see the [release verification record](docs/RELEASE_VERIFICATION.md)
-for the evidence boundary and post-publication checks.
+`SHA256SUMS.txt`. The public wheel and Windows binary were then downloaded
+without authentication and acceptance-tested from the release page; see the
+[release verification record](docs/RELEASE_VERIFICATION.md) for the evidence
+boundary and post-publication checks.
 
 v1 adds deterministic Project Cognition and the Project Reality cockpit on top
 of canonical project identity, bitemporal truth, governed context compilation,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-## v1.0.3-alpha Release Candidate
+## Published v1.0.3-alpha
 
 - Dedicated authorization recovery instead of misleading empty-brain rendering
 - Copyable managed-console reopen command with stale capability cleanup
@@ -37,7 +37,7 @@
 - Synthetic cognition quality gates for continuation, contradiction, decision debt, authority abstention, governance, and stale rejection
 - Cross-platform source, package, native artifact, browser, privacy, security, backup/restore, daemon, and MCP qualification before publication
 
-The v1.0.2 prerelease is the current public milestone. Future items below are
+The v1.0.3 prerelease is the current public milestone. Future items below are
 intentions and are not part of its evidence boundary.
 
 ## Published v0.9.1-alpha
@@ -84,7 +84,7 @@ intentions and are not part of its evidence boundary.
 - Metadata-only large-file isolation plus explicit strict blocking
 - Safe local language-server discovery and loopback-only Ollama continuity compaction
 
-## Next After v1.0.2-alpha
+## Next After v1.0.3-alpha
 
 - Expand the public benchmark with community-reviewed corpora and blinded human relevance judgments
 - Add approximate nearest-neighbor indexes for very large local embedding collections

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -2,7 +2,7 @@
 
 ## Current Prerelease
 
-[`v1.0.2-alpha`](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v1.0.2-alpha)
+[`v1.0.3-alpha`](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v1.0.3-alpha)
 is the current public prerelease. Use the source checkout or download the
 standalone binary for your operating system from that release. Verify downloads
 against its `SHA256SUMS.txt` before execution.
@@ -67,7 +67,7 @@ The repository includes a reproducible PyInstaller specification. The release
 workflow builds and smoke-tests separate Windows, macOS, and Linux artifacts,
 renames them with version/OS/architecture, and uploads a `SHA256SUMS.txt`
 manifest. The formal
-[`v1.0.2-alpha` release](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v1.0.2-alpha)
+[`v1.0.3-alpha` release](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v1.0.3-alpha)
 contains Windows x64, Linux x64, and macOS binaries, a universal wheel,
 CycloneDX SBOMs, and the combined checksum manifest.
 

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -1,14 +1,20 @@
 # Release Verification
 
-## v1.0.3-alpha Candidate Verification
+## Published v1.0.3-alpha Verification
 
-`v1.0.3-alpha` is a maintenance candidate for the v1 Project Reality line. It
-preserves schema v11 and the stable v1 interfaces while correcting two failures
-observed in real local operation: an expired console capability masquerading as
-an empty brain, and an older launcher reporting a newer schema without a safe
-recovery path.
+`v1.0.3-alpha` is the published maintenance prerelease for the v1 Project
+Reality line. It preserves schema v11 and the stable v1 interfaces while
+correcting two failures observed in real local operation: an expired console
+capability masquerading as an empty brain, and an older launcher reporting a
+newer schema without a safe recovery path.
 
-| Candidate gate | Verified evidence |
+- Merge commit: `76961d475905cb528d7959fa3b0166afe8606d0a`
+- Annotated tag: `v1.0.3-alpha`
+- Formal prerelease: [Rta-Smriti Brain v1.0.3-alpha](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v1.0.3-alpha)
+- Pull request: [#36](https://github.com/sulabhdubey/rta-smriti-brain/pull/36)
+- Public checksum-manifest SHA-256: `aea08165459a47bcc34e2203ee3bb81a92d0be16d90e3976f515f1df344d470b`
+
+| Release gate | Verified evidence |
 | --- | --- |
 | Full local regression | `806` Python tests passed, `24` explicit optional or platform skips, and `651` subtests passed; dashboard unit/security tests passed |
 | Future-schema safety | `17` focused migration tests pass; schema v99 is rejected before mutation with explicit launcher-upgrade and no-downgrade guidance |
@@ -17,12 +23,27 @@ recovery path.
 | Performance and benchmark | The bounded 100/1,000-source probe passed; synthetic retrieval, governance, cognition, and continuation gates remain green and are not represented as external superiority evidence |
 | Dependency, workflow, and secrets | Strict repository pip-audit and npm audit found no known vulnerabilities; actionlint passed; Gitleaks found no leaks in the candidate or `119` Git commits |
 | Security and privacy | Repository privacy scan passed; sealed Codex Security diff scan `170124ad-77d2-4024-8d81-e7a9019f825f` covered every changed security-relevant surface with zero findings |
-| Native Windows candidate | Standalone CLI, SQLite/FTS, MCP, benchmark, bundled Tree-sitter, Universal Capture, encrypted and Ed25519 snapshots, background sync, and managed-console smoke passed |
-| Remaining publication gates | Hosted Windows/macOS/Linux CI, immutable tag builds, public checksums, Pages deployment, and anonymous-download acceptance remain pending until publication |
+| Pull-request CI | [Run 33085756875](https://github.com/sulabhdubey/rta-smriti-brain/actions/runs/33085756875) passed all five Windows, macOS, and Ubuntu lanes |
+| Main CI and Pages | [CI run 33086951976](https://github.com/sulabhdubey/rta-smriti-brain/actions/runs/33086951976) and [Pages run 33086952076](https://github.com/sulabhdubey/rta-smriti-brain/actions/runs/33086952076) passed |
+| Tagged native artifacts | [Run 33088282341](https://github.com/sulabhdubey/rta-smriti-brain/actions/runs/33088282341) built, audited, privacy-scanned, and smoke-tested the Windows x64, Linux x64, and macOS arm64 bundles from the annotated tag |
+| Anonymous public acceptance | All eight release files downloaded without authentication; all seven payloads matched the public manifest; a clean wheel install passed `28` distribution checks; the Windows binary reported `rta-brain 1.0.3a1` and an `ok` doctor result |
+| Website alignment | Public copy identifies `v1.0.3-alpha` as current and labels the retained v1.0.2 media honestly as the v1 product capture used by this maintenance patch |
+
+### v1.0.3-alpha Release Assets
+
+| Asset | SHA-256 |
+| --- | --- |
+| `rta_smriti_brain-1.0.3a1-py3-none-any.whl` | `1cb2fe89f199273bec0609622541c27bc12946b5ed46d55312bd4ae46c2bfba3` |
+| `rta-brain-1.0.3a1-linux-x86_64` | `8968ac8bff75c3cb4b9f20380b746d7f603f118c4aadb2178934c4500ac0eed4` |
+| `rta-brain-1.0.3a1-macos-arm64` | `66d17ec1842c073d316726f00e991b06fef84fe6af0ea40f8bc83148384690d3` |
+| `rta-brain-1.0.3a1-windows-x86_64.exe` | `8088cb967b2981ae1a0ff5224536f9946e8539d5f0d2368344f711a98f4344d7` |
+| Linux CycloneDX SBOM | `73ec70a12b3b5c7c185da06d3e1d8f53c0f02c71d284f4664f1cac37a23fbccd` |
+| macOS CycloneDX SBOM | `62a9d51488b665178dbcc2539a4095277b84db86db3c09fec6c5998c18c5fdf4` |
+| Windows CycloneDX SBOM | `8e5105fd6c60374ea40be2912b6ee02fe6050146df73a9cb72eee08cbcbe371d` |
 
 ## Published v1.0.2-alpha Verification
 
-`v1.0.2-alpha` is the current public operator-hardening prerelease for v1. Its
+`v1.0.2-alpha` was the preceding operator-hardening prerelease for v1. Its
 formal annotated tag and GitHub prerelease contain the native artifacts,
 universal wheel, CycloneDX SBOMs, and checksum manifest built from tagged source.
 

--- a/launch-assets/press/PRODUCT_FACT_SHEET.md
+++ b/launch-assets/press/PRODUCT_FACT_SHEET.md
@@ -2,11 +2,11 @@
 
 **Category:** Open-source developer tool, local AI project memory
 
-**Current public prerelease:** [`v1.0.2-alpha`](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v1.0.2-alpha) (`1.0.2a1` package metadata)
+**Current public prerelease:** [`v1.0.3-alpha`](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v1.0.3-alpha) (`1.0.3a1` package metadata)
 
 **Release bundle:** SHA-256 checksums, a universal wheel, CycloneDX SBOMs, and standalone Windows, Linux, and macOS artifacts built and smoke-tested from the annotated v1 tag.
 
-**v1 milestone:** Deterministic Project Cognition and the Project Reality cockpit add readiness, project-twin conflicts, knowledge coverage, decision debt, change-impact hints, and governed local multimodal evidence on top of bitemporal truth, governed context, and Universal Capture. The v1.0.2 patch preserves that boundary while hardening hidden Windows startup, the shared terminal-independent worker lifecycle, Watchdog-first sync, adaptive polling fallback, idempotent private-directory onboarding, and dashboard accessibility.
+**v1 milestone:** Deterministic Project Cognition and the Project Reality cockpit add readiness, project-twin conflicts, knowledge coverage, decision debt, change-impact hints, and governed local multimodal evidence on top of bitemporal truth, governed context, and Universal Capture. The v1.0.3 patch preserves that boundary while making expired-console authorization recoverable and newer-schema launcher failures explicit, safe, and actionable.
 
 **Creation:** Conceived and researched by Sulabh Dubey; built with [OpenAI Codex](https://openai.com/codex/) as the primary AI engineering agent under maintainer review. See [`CONTRIBUTORS.md`](../../CONTRIBUTORS.md).
 

--- a/launch-site/index.html
+++ b/launch-site/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#050a10" />
-    <meta name="description" content="Rta-Smriti v1.0.2-alpha is a sovereign local project-memory layer with deterministic Project Reality, bitemporal truth, governed context, and evidence-aware continuity." />
+    <meta name="description" content="Rta-Smriti v1.0.3-alpha is a sovereign local project-memory layer with deterministic Project Reality, bitemporal truth, governed context, and evidence-aware continuity." />
     <meta property="og:title" content="Rta-Smriti Brain" />
     <meta property="og:description" content="Project Reality, decision debt, bitemporal project truth, local multimodal evidence, and governed context for AI coding agents." />
     <meta property="og:type" content="website" />
@@ -13,7 +13,7 @@
     <meta property="og:image" content="./assets/project-reality-v1.png" />
     <meta name="twitter:card" content="summary_large_image" />
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
-    <title>Rta-Smriti Brain v1.0.2-alpha — Inspectable project reality for AI agents</title>
+    <title>Rta-Smriti Brain v1.0.3-alpha — Inspectable project reality for AI agents</title>
   </head>
   <body>
     <div id="root"></div>

--- a/launch-site/src/main.jsx
+++ b/launch-site/src/main.jsx
@@ -28,11 +28,11 @@ import {
 import "./styles.css";
 
 const repositoryUrl = import.meta.env.VITE_REPOSITORY_URL || "https://github.com/sulabhdubey/rta-smriti-brain";
-const releaseUrl = `${repositoryUrl}/releases/tag/v1.0.2-alpha`;
-const releaseNotesUrl = `${repositoryUrl}/blob/main/docs/RELEASE_NOTES_v1.0.2-alpha.md`;
+const releaseUrl = `${repositoryUrl}/releases/tag/v1.0.3-alpha`;
+const releaseNotesUrl = `${repositoryUrl}/blob/main/docs/RELEASE_NOTES_v1.0.3-alpha.md`;
 const ciRunUrl = `${repositoryUrl}/actions/workflows/ci.yml`;
 const nativeRunUrl = `${repositoryUrl}/actions/workflows/binaries.yml`;
-const productHuntUrl = "https://www.producthunt.com/products/rta-smriti-brain?launch=rta-smriti-brain&utm_source=website&utm_medium=referral&utm_campaign=v102_release";
+const productHuntUrl = "https://www.producthunt.com/products/rta-smriti-brain?launch=rta-smriti-brain&utm_source=website&utm_medium=referral&utm_campaign=v103_release";
 
 
 const installCommands = {
@@ -107,12 +107,12 @@ function Hero() {
       <div className="heroScrim" />
       <HeroGraph />
       <div className="heroContent shell">
-        <div className="eyebrow"><LockKeyhole size={14} /> v1.0.2-alpha · Project Reality · Local-first</div>
+        <div className="eyebrow"><LockKeyhole size={14} /> v1.0.3-alpha · Project Reality · Local-first</div>
         <h1>Rta-Smriti Brain</h1>
         <p className="heroLead">A sovereign project-memory layer that reconciles repository evidence, temporal truth, decisions, work state, and local media into an inspectable reality for the next AI task.</p>
         <p className="buildCredit">Conceived and researched by <a href="https://github.com/sulabhdubey">Sulabh Dubey</a>. Built with <a href="https://openai.com/codex/">OpenAI Codex</a> as the primary AI engineering agent under maintainer review.</p>
         <div className="heroActions">
-          <a className="primaryAction" href={releaseUrl}><TerminalSquare size={18} /> Get v1.0.2 <ArrowRight size={17} /></a>
+          <a className="primaryAction" href={releaseUrl}><TerminalSquare size={18} /> Get v1.0.3 <ArrowRight size={17} /></a>
           <a className="secondaryAction" href="#demo"><Play size={17} /> Watch the product</a>
         </div>
         <a className="launchConversation" href={productHuntUrl}><MessageCircle size={15} /> Live on Product Hunt <span>Join the conversation</span><ExternalLink size={13} /></a>
@@ -282,8 +282,8 @@ function Demo() {
     <section className="demoSection" id="demo">
       <div className="shell demoGrid">
         <div>
-          <span className="sectionIndex">07 / v1.0.2 PRODUCT TOUR</span>
-          <h2>From project evidence to governed continuity in sixty seconds.</h2>
+          <span className="sectionIndex">07 / v1 PRODUCT TOUR</span>
+          <h2>From project evidence to governed continuity in sixty seconds.</h2><p className="demoVersionNote">Captured from v1.0.2. v1.0.3 keeps this Project Reality experience and adds authorization recovery plus safe launcher-upgrade guidance.</p>
           <ol>
             <li><span>1</span>Start one canonical project brain.</li>
             <li><span>2</span>Capture bounded agent activity without promoting it to truth.</li>
@@ -292,9 +292,9 @@ function Demo() {
           </ol>
         </div>
         <div className="demoVisual">
-          <video controls preload="metadata" poster="./assets/rta-smriti-v1.0.2-product-demo-poster.png" aria-label="60-second Rta-Smriti Brain v1.0.2 product tour">
+          <video controls preload="metadata" poster="./assets/rta-smriti-v1.0.2-product-demo-poster.png" aria-label="60-second Rta-Smriti Brain v1 product tour captured from v1.0.2">
             <source src="./assets/rta-smriti-v1.0.2-product-demo.mp4" type="video/mp4" />
-            Your browser does not support embedded video. <a href="./assets/rta-smriti-v1.0.2-product-demo.mp4">Open the v1.0.2 MP4 demo.</a>
+            Your browser does not support embedded video. <a href="./assets/rta-smriti-v1.0.2-product-demo.mp4">Open the v1 product tour captured from v1.0.2.</a>
           </video>
         </div>
       </div>
@@ -338,6 +338,7 @@ function ReleaseStory() {
     ["v0.9.1", "Operator-ready Universal Capture", "Progressive multi-project loading, race-safe project isolation, bounded capture diagnostics, and verified cross-platform artifacts."],
     ["v1.0.1", "Operator-ready Project Reality", "Deterministic readiness, project twin, decision debt, coverage, change impact, and race-safe local operator interfaces."],
     ["v1.0.2", "Hardened operator lifecycle", "Hidden Windows startup, shared terminal-independent workers, Watchdog-first sync, adaptive polling, and WCAG AA corrections."],
+    ["v1.0.3", "Recoverable local operation", "Expired console capabilities become a guided reopen flow; newer-schema launchers provide non-mutating upgrade instructions."],
   ];
   return (
     <section className="releaseStory" id="release">
@@ -382,7 +383,7 @@ function AssetBoard({ name }) {
   return (
     <div className={`assetCanvas ${assetClass}`}>
       <div className="assetTop"><Brand compact /><span>LOCAL ONLY</span></div>
-      <div className="assetCopy"><small>RTA-SMRITI BRAIN · v1.0.2-alpha</small><h1>{content[0]}</h1><p>{content[1]}</p></div>
+      <div className="assetCopy"><small>RTA-SMRITI BRAIN · v1.0.3-alpha</small><h1>{content[0]}</h1><p>{content[1]}</p></div>
       {content[2] === "dashboard" && <img src="./assets/project-reality-v1.0.2.png" alt="" />}
       {content[2] === "agents" && <div className="assetAgentOrbit"><BrainCircuit />{agents.slice(0, 7).map((agent, i) => <span key={agent} style={{ "--i": i }}>{agent}</span>)}</div>}
       {content[2] === "pramana" && <div className="assetPramana">{Object.entries(pramana).map(([key, value]) => <span key={key} style={{ "--color": value[2] }}><i />{key}<small>{value[0]}</small></span>)}</div>}

--- a/scripts/launch_site_qa.mjs
+++ b/scripts/launch_site_qa.mjs
@@ -87,13 +87,13 @@ try {
   await page.getByRole("heading", { name: "Rta-Smriti Brain", exact: true }).waitFor();
   assert.equal(await page.locator(".heroImage").evaluate((image) => image.naturalWidth > 0), true);
   const bodyText = await page.locator("body").innerText();
-  assert.match(bodyText, /v1\.0\.2-alpha/i);
-  const releaseLink = page.getByRole("link", { name: "Get v1.0.2", exact: true });
-  assert.match(await releaseLink.getAttribute("href"), /\/releases\/tag\/v1\.0\.2-alpha$/);
+  assert.match(bodyText, /v1\.0\.3-alpha/i);
+  const releaseLink = page.getByRole("link", { name: "Get v1.0.3", exact: true });
+  assert.match(await releaseLink.getAttribute("href"), /\/releases\/tag\/v1\.0\.3-alpha$/);
   assert.match(bodyText, /Universal Capture/);
   assert.match(bodyText, /Bitemporal/);
   assert.match(bodyText, /Context Compiler/i);
-  assert.match(bodyText, /v1\.0\.2 product tour/i);
+  assert.match(bodyText, /captured from v1\.0\.2/i);
 
 
 

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -8,6 +8,7 @@ from rta_brain import __version__
 ROOT = Path(__file__).resolve().parents[1]
 EXPECTED_PYTHON_VERSION = "1.0.3a1"
 EXPECTED_DISPLAY_VERSION = "1.0.3-alpha"
+PUBLISHED_CURRENT = "v1.0.3-alpha"
 PUBLISHED_BASELINE = "v1.0.2-alpha"
 PUBLISHED_BASELINE_COMMIT = "272674cca094447a35307c93ceb05863b84a1b50"
 
@@ -42,21 +43,23 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertNotIn('"0.9.1a1" not in version', binary_smoke)
         self.assertLess(binary_smoke.index("root = Path(__file__)"), binary_smoke.index("expected_version = str(tomllib.loads"))
         self.assertIn("v1.0.3 Alpha Operator Console", dashboard)
-        self.assertIn("version: 1.0.2-alpha", citation)
+        self.assertIn(f"version: {PUBLISHED_CURRENT.removeprefix('v')}", citation)
+        self.assertIn("## Published v1.0.3-alpha", roadmap)
         self.assertIn("## Published v1.0.2-alpha", roadmap)
         self.assertIn("## Published v1.0.1-alpha", roadmap)
         self.assertIn("## Published v1.0.0-alpha", roadmap)
         self.assertIn("## Published v0.9.1-alpha", roadmap)
-        self.assertIn("## [1.0.2-alpha] - 2026-08-26", changelog)
-        self.assertIn("**Current public prerelease:** [`v1.0.2-alpha`]", fact_sheet)
+        self.assertIn("## [1.0.3-alpha] - 2026-08-27", changelog)
+        self.assertIn("**Current public prerelease:** [`v1.0.3-alpha`]", fact_sheet)
         self.assertIn("**Release bundle:** SHA-256 checksums", fact_sheet)
-        self.assertIn("## v1.0.2-alpha", readme)
-        self.assertIn("Current release: v1.0.2-alpha", readme)
+        self.assertIn("## v1.0.3-alpha", readme)
+        self.assertIn("Current release: v1.0.3-alpha", readme)
         self.assertIn("Project Reality", launch_site)
         self.assertIn("project-reality-v1.0.2.png", launch_site)
         self.assertNotIn("Creator-Brief", readme + fact_sheet + launch_site)
-        self.assertIn("/releases/tag/v1.0.2-alpha", launch_site)
-        self.assertNotIn("v1.0.2-alpha Candidate", roadmap + readme)
+        self.assertIn("/releases/tag/v1.0.3-alpha", launch_site)
+        self.assertIn("captured from v1.0.2", launch_site)
+        self.assertNotIn("v1.0.3-alpha Release Candidate", roadmap + readme)
         self.assertNotIn("v1.0.1-alpha remains the current public prerelease", roadmap + readme + release_notes)
         self.assertIn("## Project Reality In v1", usage)
         self.assertIn("--json cognition --project", usage)
@@ -66,6 +69,9 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertIn("## Stable Interfaces", architecture)
         self.assertIn("Alpha prerelease", release_notes)
         self.assertIn("maintenance patch", release_notes)
+        self.assertIn("## Published v1.0.3-alpha Verification", release_verification)
+        self.assertIn("33088282341", release_verification)
+        self.assertIn("aea08165459a47bcc34e2203ee3bb81a92d0be16d90e3976f515f1df344d470b", release_verification)
         self.assertIn("## Published v1.0.2-alpha Verification", release_verification)
         self.assertIn("## Published v1.0.1-alpha Verification", release_verification)
         self.assertIn("c2dff01b368bdb4d2b759e7a077d07ae0985a966", release_verification)
@@ -74,6 +80,7 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertIn("/releases/tag/v1.0.0-alpha", release_verification)
         self.assertNotIn("Pending the approved `v1.0.0-alpha` tag workflow", release_verification)
         self.assertNotIn("Pending formal publication", release_verification)
+        self.assertNotIn("Remaining publication gates", release_verification)
         self.assertIn("# v1 Project Cognition Threat Model", threat_model)
 
         self.assertIn("Conceived and researched by [Sulabh Dubey]", readme)


### PR DESCRIPTION
## Summary
- identify v1.0.3-alpha as the current public prerelease across README, citation, installation, roadmap, and fact sheet
- seal hosted CI, native artifact, checksum, and anonymous-install evidence
- align the launch site and browser contract while honestly labelling retained v1.0.2 product media

## Verification
- release metadata/community tests: 8 passed
- launch production build and desktop/mobile/interactions/media/links/accessibility QA: passed
- privacy scan: passed
- npm audit: 0 vulnerabilities
- staged Gitleaks: no leaks
- staged diff check: passed

No private brain data, local paths, slide deck, email, generated artifacts, or release binaries are included.