### PR TITLE
docs: publish v1.0.4 release verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.0.4-alpha] - 2026-08-27
+
+- Isolated installed CLI and MCP module launchers from stale checkout packages in the current working directory.
+- Added hostile-working-directory upgrade coverage from `v1.0.3-alpha` to `v1.0.4-alpha` without changing source-script or native-binary behavior.
+- Requalified the exact tag across source, clean installation, native artifacts, rendered operator UX, privacy, security, and hosted cross-platform CI.
+
 ## [1.0.3-alpha] - 2026-08-27
 
 - Replaced unauthorized empty-brain rendering with explicit managed-console recovery.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ type: software
 authors:
   - family-names: Dubey
     given-names: Sulabh
-version: 1.0.3-alpha
+version: 1.0.4-alpha
 license: MIT
 abstract: "Local-first project memory, repository graph, context packs, and MCP tools for AI coding agents. Conceived and researched by Sulabh Dubey; built with OpenAI Codex as the primary AI engineering agent under maintainer review."
 repository-code: "https://github.com/sulabhdubey/rta-smriti-brain"

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Rta-Smriti Brain
 
-## v1.0.3-alpha
+## v1.0.4-alpha
 
-`v1.0.3-alpha` is the current maintenance prerelease for the v1 release line.
-It replaces misleading empty-brain rendering after an expired console
-capability with a direct recovery path, and turns newer-schema launcher failures
-into actionable, non-mutating upgrade guidance. See the
-[release notes](docs/RELEASE_NOTES_v1.0.3-alpha.md)
+`v1.0.4-alpha` is the current maintenance prerelease for the v1 release line.
+It preserves the v1 Project Reality boundary, authorization recovery, and safe
+schema diagnostics while isolating installed CLI and MCP launchers from an old
+checkout in the current working directory. See the
+[release notes](docs/RELEASE_NOTES_v1.0.4-alpha.md)
 and bounded [verification ledger](docs/RELEASE_VERIFICATION.md).
 
 v1 turns the brain from a searchable index into an inspectable project-reality
@@ -22,13 +22,13 @@ work, route models, or replace an agent harness.
 [![Release](https://img.shields.io/github/v/release/sulabhdubey/rta-smriti-brain?include_prereleases&label=release)](https://github.com/sulabhdubey/rta-smriti-brain/releases)
 [![License: MIT](https://img.shields.io/badge/license-MIT-2ea44f.svg)](LICENSE)
 
-**A sovereign local project-memory and evidence layer for AI coding agents. The `v1.0.3-alpha` release preserves deterministic Project Reality while hardening authorization recovery, launcher upgrades, and schema-compatibility diagnostics.**
+**A sovereign local project-memory and evidence layer for AI coding agents. The `v1.0.4-alpha` release preserves deterministic Project Reality while isolating installed launchers from stale checkout code.**
 
 **Build provenance:** Conceived and researched by [Sulabh Dubey](https://github.com/sulabhdubey). Built with [OpenAI Codex](https://openai.com/codex/) as the primary design, engineering, testing, and documentation agent under Sulabh's product direction and release approval. [Details](CONTRIBUTORS.md).
 
 Rta-Smriti now connects repository intelligence, durable decisions, agent-session continuity, and evidence-aware retrieval through a private local event journal. Capture is opt-in, bounded, redacted before durable queuing, and explicitly treated as untrusted evidence until an operator or verifier promotes a claim.
 
-[Current release: v1.0.3-alpha](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v1.0.3-alpha) · [Release notes](docs/RELEASE_NOTES_v1.0.3-alpha.md) · [Live website](https://sulabhdubey.github.io/rta-smriti-brain/) · [60-second v1 product demo (captured from v1.0.2)](launch-assets/product-hunt/rta-smriti-v1.0.2-product-demo.mp4) · [Installation](docs/INSTALLATION.md) · [Usage guide](docs/USAGE_GUIDE.md) · [Architecture](docs/ARCHITECTURE.md) · [Public benchmark](docs/PUBLIC_BENCHMARK.md) · [Release verification](docs/RELEASE_VERIFICATION.md) · [Build provenance](CONTRIBUTORS.md) · [Security](SECURITY.md) · [Roadmap](ROADMAP.md)
+[Current release: v1.0.4-alpha](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v1.0.4-alpha) · [Release notes](docs/RELEASE_NOTES_v1.0.4-alpha.md) · [Live website](https://sulabhdubey.github.io/rta-smriti-brain/) · [60-second v1 product demo (captured from v1.0.2)](launch-assets/product-hunt/rta-smriti-v1.0.2-product-demo.mp4) · [Installation](docs/INSTALLATION.md) · [Usage guide](docs/USAGE_GUIDE.md) · [Architecture](docs/ARCHITECTURE.md) · [Public benchmark](docs/PUBLIC_BENCHMARK.md) · [Release verification](docs/RELEASE_VERIFICATION.md) · [Build provenance](CONTRIBUTORS.md) · [Security](SECURITY.md) · [Roadmap](ROADMAP.md)
 
 Rta-Smriti Brain turns a project repository, long agent threads, durable decisions, and evidence into a small local memory graph that Codex, Claude Code, Cursor, or any MCP-capable agent can reuse before doing work.
 
@@ -40,7 +40,7 @@ Rta-Smriti gives each project a memory that stays on your machine.
 
 ## Latest Release
 
-[`v1.0.3-alpha`](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v1.0.3-alpha)
+[`v1.0.4-alpha`](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v1.0.4-alpha)
 is the current published prerelease. The exact tagged source passes the hosted
 Windows, macOS, and Ubuntu matrix across Python 3.11, 3.12, and 3.13. The native
 workflow builds and smoke-tests Windows x64, Linux x64, and macOS standalone

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,5 +1,12 @@
 # Roadmap
 
+## Published v1.0.4-alpha
+
+- Isolated installed CLI and MCP module launchers from stale packages in the current working directory
+- Preserved source-script and native-binary launch behavior while hardening only installed wrappers
+- Added hostile-working-directory upgrade regression coverage from the previous public prerelease
+- Requalified source, clean-package upgrade, native artifacts, rendered UX, privacy, security, and hosted cross-platform CI
+
 ## Published v1.0.3-alpha
 
 - Dedicated authorization recovery instead of misleading empty-brain rendering
@@ -37,7 +44,7 @@
 - Synthetic cognition quality gates for continuation, contradiction, decision debt, authority abstention, governance, and stale rejection
 - Cross-platform source, package, native artifact, browser, privacy, security, backup/restore, daemon, and MCP qualification before publication
 
-The v1.0.3 prerelease is the current public milestone. Future items below are
+The v1.0.4 prerelease is the current public milestone. Future items below are
 intentions and are not part of its evidence boundary.
 
 ## Published v0.9.1-alpha
@@ -84,7 +91,7 @@ intentions and are not part of its evidence boundary.
 - Metadata-only large-file isolation plus explicit strict blocking
 - Safe local language-server discovery and loopback-only Ollama continuity compaction
 
-## Next After v1.0.3-alpha
+## Next After v1.0.4-alpha
 
 - Expand the public benchmark with community-reviewed corpora and blinded human relevance judgments
 - Add approximate nearest-neighbor indexes for very large local embedding collections

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -2,7 +2,7 @@
 
 ## Current Prerelease
 
-[`v1.0.3-alpha`](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v1.0.3-alpha)
+[`v1.0.4-alpha`](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v1.0.4-alpha)
 is the current public prerelease. Use the source checkout or download the
 standalone binary for your operating system from that release. Verify downloads
 against its `SHA256SUMS.txt` before execution.
@@ -67,7 +67,7 @@ The repository includes a reproducible PyInstaller specification. The release
 workflow builds and smoke-tests separate Windows, macOS, and Linux artifacts,
 renames them with version/OS/architecture, and uploads a `SHA256SUMS.txt`
 manifest. The formal
-[`v1.0.3-alpha` release](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v1.0.3-alpha)
+[`v1.0.4-alpha` release](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v1.0.4-alpha)
 contains Windows x64, Linux x64, and macOS binaries, a universal wheel,
 CycloneDX SBOMs, and the combined checksum manifest.
 

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -1,5 +1,45 @@
 # Release Verification
 
+## Published v1.0.4-alpha Verification
+
+`v1.0.4-alpha` is the current published maintenance prerelease for the v1
+Project Reality line. It preserves schema v11 and the stable v1 interfaces while
+isolating installed CLI and MCP module launchers from stale checkout packages in
+the current working directory. Source-script and native-binary launch behavior
+remain unchanged.
+
+- Merge commit: `cff3e5cca9243b52e2e233c453ab82fcb11fdac8`
+- Annotated tag: `v1.0.4-alpha`
+- Formal prerelease: [Rta-Smriti Brain v1.0.4-alpha](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v1.0.4-alpha)
+- Pull request: [#38](https://github.com/sulabhdubey/rta-smriti-brain/pull/38)
+- Public checksum-manifest SHA-256: `62dd2a5a2befd4365994e2668e5e655ddc262771a0ff27751f35d7e8aa526837`
+
+| Release gate | Verified evidence |
+| --- | --- |
+| Full local regression | `806` Python tests passed, `24` explicit optional or platform skips, and `651` subtests passed; dashboard unit/security tests passed |
+| Installed upgrade isolation | Clean `v1.0.3-alpha` to `v1.0.4-alpha` installation, hostile-working-directory launcher verification, candidate checks, and uninstall passed |
+| Rendered operator UX | All `9` rendered operator journeys passed; launch-site desktop, mobile, interaction, media, link, and accessibility QA passed |
+| Performance and benchmark | The bounded 100/1,000-source probe passed; the public synthetic retrieval, governance, cognition, and continuation gates remained green |
+| Dependency, workflow, and secrets | Strict repository pip-audit and npm audit found no known vulnerabilities; actionlint passed; Gitleaks found no leaks |
+| Security and privacy | Repository privacy scans passed; sealed Codex Security diff scan `ee507c28-2011-4fab-a19c-46d3b510255e` covered all four changed security-relevant surfaces with zero findings |
+| Pull-request CI | [Run 33097997330](https://github.com/sulabhdubey/rta-smriti-brain/actions/runs/33097997330) passed all five Windows, macOS, and Ubuntu lanes |
+| Main CI and Pages | [CI run 33099163186](https://github.com/sulabhdubey/rta-smriti-brain/actions/runs/33099163186) and [Pages run 33099163185](https://github.com/sulabhdubey/rta-smriti-brain/actions/runs/33099163185) passed |
+| Tagged native artifacts | [Run 33100314048](https://github.com/sulabhdubey/rta-smriti-brain/actions/runs/33100314048) built, audited, privacy-scanned, and smoke-tested the Windows x64, Linux x64, and macOS arm64 bundles from the annotated tag |
+| Anonymous public acceptance | All eight release files downloaded without authentication; all seven payloads matched the public manifest; a clean wheel install passed `28` distribution checks; the Windows binary reported `rta-brain 1.0.4a1`; doctor passed after enforcing the documented private brain-directory ACL |
+| Website alignment | Public copy identifies `v1.0.4-alpha` as current and labels retained v1.0.2 screenshots and video honestly as the v1 product capture preserved by this maintenance patch |
+
+### v1.0.4-alpha Release Assets
+
+| Asset | SHA-256 |
+| --- | --- |
+| `rta_smriti_brain-1.0.4a1-py3-none-any.whl` | `e390cdcf97362f14cb9646d68e3f2fe2c72b4ec2bdd47ca208c510c6a66e36a8` |
+| `rta-brain-1.0.4a1-linux-x86_64` | `ed41a0343861e2ac9668c37d927282c0b99e57e49b4b1d95a2055e05a4bd3aa9` |
+| `rta-brain-1.0.4a1-macos-arm64` | `24fdcc3699142f6acf9c43313b696f4485de0565e18f05bc6fab1a144a42cc41` |
+| `rta-brain-1.0.4a1-windows-x86_64.exe` | `181155d5bcd77f5efacb3090a7adf22aba39a260791aa7cad3a0b11aff953623` |
+| Linux CycloneDX SBOM | `87d8d41ee8d511326b1e24629eaac21c478ba6bf34dc1408721934cfc797d51e` |
+| macOS CycloneDX SBOM | `e112441b2670839b80bec7c63402502eac634de236e1d8022b9c4e18da87d9cf` |
+| Windows CycloneDX SBOM | `26d8bca6cd36cfb58fa08a8b10b468cfdb5ec4a3856fad9b063c683217c9804c` |
+
 ## Published v1.0.3-alpha Verification
 
 `v1.0.3-alpha` is the published maintenance prerelease for the v1 Project
@@ -27,7 +67,7 @@ newer schema without a safe recovery path.
 | Main CI and Pages | [CI run 33086951976](https://github.com/sulabhdubey/rta-smriti-brain/actions/runs/33086951976) and [Pages run 33086952076](https://github.com/sulabhdubey/rta-smriti-brain/actions/runs/33086952076) passed |
 | Tagged native artifacts | [Run 33088282341](https://github.com/sulabhdubey/rta-smriti-brain/actions/runs/33088282341) built, audited, privacy-scanned, and smoke-tested the Windows x64, Linux x64, and macOS arm64 bundles from the annotated tag |
 | Anonymous public acceptance | All eight release files downloaded without authentication; all seven payloads matched the public manifest; a clean wheel install passed `28` distribution checks; the Windows binary reported `rta-brain 1.0.3a1` and an `ok` doctor result |
-| Website alignment | Public copy identifies `v1.0.3-alpha` as current and labels the retained v1.0.2 media honestly as the v1 product capture used by this maintenance patch |
+| Website alignment | At publication time, public copy identified `v1.0.3-alpha` as current and labelled the retained v1.0.2 media honestly as the v1 product capture used by that maintenance patch |
 
 ### v1.0.3-alpha Release Assets
 

--- a/launch-assets/press/PRODUCT_FACT_SHEET.md
+++ b/launch-assets/press/PRODUCT_FACT_SHEET.md
@@ -2,11 +2,11 @@
 
 **Category:** Open-source developer tool, local AI project memory
 
-**Current public prerelease:** [`v1.0.3-alpha`](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v1.0.3-alpha) (`1.0.3a1` package metadata)
+**Current public prerelease:** [`v1.0.4-alpha`](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v1.0.4-alpha) (`1.0.4a1` package metadata)
 
 **Release bundle:** SHA-256 checksums, a universal wheel, CycloneDX SBOMs, and standalone Windows, Linux, and macOS artifacts built and smoke-tested from the annotated v1 tag.
 
-**v1 milestone:** Deterministic Project Cognition and the Project Reality cockpit add readiness, project-twin conflicts, knowledge coverage, decision debt, change-impact hints, and governed local multimodal evidence on top of bitemporal truth, governed context, and Universal Capture. The v1.0.3 patch preserves that boundary while making expired-console authorization recoverable and newer-schema launcher failures explicit, safe, and actionable.
+**v1 milestone:** Deterministic Project Cognition and the Project Reality cockpit add readiness, project-twin conflicts, knowledge coverage, decision debt, change-impact hints, and governed local multimodal evidence on top of bitemporal truth, governed context, and Universal Capture. The v1.0.4 patch preserves that boundary while isolating installed CLI and MCP wrappers from stale checkout code, retaining recoverable console authorization and explicit safe schema diagnostics.
 
 **Creation:** Conceived and researched by Sulabh Dubey; built with [OpenAI Codex](https://openai.com/codex/) as the primary AI engineering agent under maintainer review. See [`CONTRIBUTORS.md`](../../CONTRIBUTORS.md).
 

--- a/launch-site/index.html
+++ b/launch-site/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#050a10" />
-    <meta name="description" content="Rta-Smriti v1.0.3-alpha is a sovereign local project-memory layer with deterministic Project Reality, bitemporal truth, governed context, and evidence-aware continuity." />
+    <meta name="description" content="Rta-Smriti v1.0.4-alpha is a sovereign local project-memory layer with deterministic Project Reality, bitemporal truth, governed context, and evidence-aware continuity." />
     <meta property="og:title" content="Rta-Smriti Brain" />
     <meta property="og:description" content="Project Reality, decision debt, bitemporal project truth, local multimodal evidence, and governed context for AI coding agents." />
     <meta property="og:type" content="website" />
@@ -13,7 +13,7 @@
     <meta property="og:image" content="./assets/project-reality-v1.png" />
     <meta name="twitter:card" content="summary_large_image" />
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
-    <title>Rta-Smriti Brain v1.0.3-alpha — Inspectable project reality for AI agents</title>
+    <title>Rta-Smriti Brain v1.0.4-alpha — Inspectable project reality for AI agents</title>
   </head>
   <body>
     <div id="root"></div>

--- a/launch-site/src/main.jsx
+++ b/launch-site/src/main.jsx
@@ -28,11 +28,11 @@ import {
 import "./styles.css";
 
 const repositoryUrl = import.meta.env.VITE_REPOSITORY_URL || "https://github.com/sulabhdubey/rta-smriti-brain";
-const releaseUrl = `${repositoryUrl}/releases/tag/v1.0.3-alpha`;
-const releaseNotesUrl = `${repositoryUrl}/blob/main/docs/RELEASE_NOTES_v1.0.3-alpha.md`;
+const releaseUrl = `${repositoryUrl}/releases/tag/v1.0.4-alpha`;
+const releaseNotesUrl = `${repositoryUrl}/blob/main/docs/RELEASE_NOTES_v1.0.4-alpha.md`;
 const ciRunUrl = `${repositoryUrl}/actions/workflows/ci.yml`;
 const nativeRunUrl = `${repositoryUrl}/actions/workflows/binaries.yml`;
-const productHuntUrl = "https://www.producthunt.com/products/rta-smriti-brain?launch=rta-smriti-brain&utm_source=website&utm_medium=referral&utm_campaign=v103_release";
+const productHuntUrl = "https://www.producthunt.com/products/rta-smriti-brain?launch=rta-smriti-brain&utm_source=website&utm_medium=referral&utm_campaign=v104_release";
 
 
 const installCommands = {
@@ -107,12 +107,12 @@ function Hero() {
       <div className="heroScrim" />
       <HeroGraph />
       <div className="heroContent shell">
-        <div className="eyebrow"><LockKeyhole size={14} /> v1.0.3-alpha · Project Reality · Local-first</div>
+        <div className="eyebrow"><LockKeyhole size={14} /> v1.0.4-alpha · Project Reality · Local-first</div>
         <h1>Rta-Smriti Brain</h1>
         <p className="heroLead">A sovereign project-memory layer that reconciles repository evidence, temporal truth, decisions, work state, and local media into an inspectable reality for the next AI task.</p>
         <p className="buildCredit">Conceived and researched by <a href="https://github.com/sulabhdubey">Sulabh Dubey</a>. Built with <a href="https://openai.com/codex/">OpenAI Codex</a> as the primary AI engineering agent under maintainer review.</p>
         <div className="heroActions">
-          <a className="primaryAction" href={releaseUrl}><TerminalSquare size={18} /> Get v1.0.3 <ArrowRight size={17} /></a>
+          <a className="primaryAction" href={releaseUrl}><TerminalSquare size={18} /> Get v1.0.4 <ArrowRight size={17} /></a>
           <a className="secondaryAction" href="#demo"><Play size={17} /> Watch the product</a>
         </div>
         <a className="launchConversation" href={productHuntUrl}><MessageCircle size={15} /> Live on Product Hunt <span>Join the conversation</span><ExternalLink size={13} /></a>
@@ -283,7 +283,7 @@ function Demo() {
       <div className="shell demoGrid">
         <div>
           <span className="sectionIndex">07 / v1 PRODUCT TOUR</span>
-          <h2>From project evidence to governed continuity in sixty seconds.</h2><p className="demoVersionNote">Captured from v1.0.2. v1.0.3 keeps this Project Reality experience and adds authorization recovery plus safe launcher-upgrade guidance.</p>
+          <h2>From project evidence to governed continuity in sixty seconds.</h2><p className="demoVersionNote">Captured from v1.0.2. v1.0.4 preserves this Project Reality experience and isolates installed CLI and MCP launchers from stale checkout code.</p>
           <ol>
             <li><span>1</span>Start one canonical project brain.</li>
             <li><span>2</span>Capture bounded agent activity without promoting it to truth.</li>
@@ -339,6 +339,7 @@ function ReleaseStory() {
     ["v1.0.1", "Operator-ready Project Reality", "Deterministic readiness, project twin, decision debt, coverage, change impact, and race-safe local operator interfaces."],
     ["v1.0.2", "Hardened operator lifecycle", "Hidden Windows startup, shared terminal-independent workers, Watchdog-first sync, adaptive polling, and WCAG AA corrections."],
     ["v1.0.3", "Recoverable local operation", "Expired console capabilities become a guided reopen flow; newer-schema launchers provide non-mutating upgrade instructions."],
+    ["v1.0.4", "Isolated installed launchers", "Installed CLI and MCP wrappers ignore stale checkout packages while preserving script and native-binary behavior."],
   ];
   return (
     <section className="releaseStory" id="release">
@@ -383,7 +384,7 @@ function AssetBoard({ name }) {
   return (
     <div className={`assetCanvas ${assetClass}`}>
       <div className="assetTop"><Brand compact /><span>LOCAL ONLY</span></div>
-      <div className="assetCopy"><small>RTA-SMRITI BRAIN · v1.0.3-alpha</small><h1>{content[0]}</h1><p>{content[1]}</p></div>
+      <div className="assetCopy"><small>RTA-SMRITI BRAIN · v1.0.4-alpha</small><h1>{content[0]}</h1><p>{content[1]}</p></div>
       {content[2] === "dashboard" && <img src="./assets/project-reality-v1.0.2.png" alt="" />}
       {content[2] === "agents" && <div className="assetAgentOrbit"><BrainCircuit />{agents.slice(0, 7).map((agent, i) => <span key={agent} style={{ "--i": i }}>{agent}</span>)}</div>}
       {content[2] === "pramana" && <div className="assetPramana">{Object.entries(pramana).map(([key, value]) => <span key={key} style={{ "--color": value[2] }}><i />{key}<small>{value[0]}</small></span>)}</div>}

--- a/scripts/launch_site_qa.mjs
+++ b/scripts/launch_site_qa.mjs
@@ -87,9 +87,9 @@ try {
   await page.getByRole("heading", { name: "Rta-Smriti Brain", exact: true }).waitFor();
   assert.equal(await page.locator(".heroImage").evaluate((image) => image.naturalWidth > 0), true);
   const bodyText = await page.locator("body").innerText();
-  assert.match(bodyText, /v1\.0\.3-alpha/i);
-  const releaseLink = page.getByRole("link", { name: "Get v1.0.3", exact: true });
-  assert.match(await releaseLink.getAttribute("href"), /\/releases\/tag\/v1\.0\.3-alpha$/);
+  assert.match(bodyText, /v1\.0\.4-alpha/i);
+  const releaseLink = page.getByRole("link", { name: "Get v1.0.4", exact: true });
+  assert.match(await releaseLink.getAttribute("href"), /\/releases\/tag\/v1\.0\.4-alpha$/);
   assert.match(bodyText, /Universal Capture/);
   assert.match(bodyText, /Bitemporal/);
   assert.match(bodyText, /Context Compiler/i);

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -8,7 +8,7 @@ from rta_brain import __version__
 ROOT = Path(__file__).resolve().parents[1]
 EXPECTED_PYTHON_VERSION = "1.0.4a1"
 EXPECTED_DISPLAY_VERSION = "1.0.4-alpha"
-PUBLISHED_CURRENT = "v1.0.3-alpha"
+PUBLISHED_CURRENT = "v1.0.4-alpha"
 PUBLISHED_BASELINE = "v1.0.3-alpha"
 PUBLISHED_BASELINE_COMMIT = "76961d475905cb528d7959fa3b0166afe8606d0a"
 
@@ -49,17 +49,17 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertIn("## Published v1.0.1-alpha", roadmap)
         self.assertIn("## Published v1.0.0-alpha", roadmap)
         self.assertIn("## Published v0.9.1-alpha", roadmap)
-        self.assertIn("## [1.0.3-alpha] - 2026-08-27", changelog)
-        self.assertIn("**Current public prerelease:** [`v1.0.3-alpha`]", fact_sheet)
+        self.assertIn("## [1.0.4-alpha] - 2026-08-27", changelog)
+        self.assertIn("**Current public prerelease:** [`v1.0.4-alpha`]", fact_sheet)
         self.assertIn("**Release bundle:** SHA-256 checksums", fact_sheet)
-        self.assertIn("## v1.0.3-alpha", readme)
-        self.assertIn("Current release: v1.0.3-alpha", readme)
+        self.assertIn("## v1.0.4-alpha", readme)
+        self.assertIn("Current release: v1.0.4-alpha", readme)
         self.assertIn("Project Reality", launch_site)
         self.assertIn("project-reality-v1.0.2.png", launch_site)
         self.assertNotIn("Creator-Brief", readme + fact_sheet + launch_site)
-        self.assertIn("/releases/tag/v1.0.3-alpha", launch_site)
+        self.assertIn("/releases/tag/v1.0.4-alpha", launch_site)
         self.assertIn("captured from v1.0.2", launch_site)
-        self.assertNotIn("v1.0.3-alpha Release Candidate", roadmap + readme)
+        self.assertNotIn("v1.0.4-alpha Release Candidate", roadmap + readme)
         self.assertNotIn("v1.0.1-alpha remains the current public prerelease", roadmap + readme + release_notes)
         self.assertIn("## Project Reality In v1", usage)
         self.assertIn("--json cognition --project", usage)
@@ -69,9 +69,10 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertIn("## Stable Interfaces", architecture)
         self.assertIn("Alpha prerelease", release_notes)
         self.assertIn("launcher-integrity patch", release_notes)
+        self.assertIn("## Published v1.0.4-alpha Verification", release_verification)
+        self.assertIn("33100314048", release_verification)
+        self.assertIn("62dd2a5a2befd4365994e2668e5e655ddc262771a0ff27751f35d7e8aa526837", release_verification)
         self.assertIn("## Published v1.0.3-alpha Verification", release_verification)
-        self.assertIn("33088282341", release_verification)
-        self.assertIn("aea08165459a47bcc34e2203ee3bb81a92d0be16d90e3976f515f1df344d470b", release_verification)
         self.assertIn("## Published v1.0.2-alpha Verification", release_verification)
         self.assertIn("## Published v1.0.1-alpha Verification", release_verification)
         self.assertIn("c2dff01b368bdb4d2b759e7a077d07ae0985a966", release_verification)


### PR DESCRIPTION
## Summary
- align README, installation, roadmap, changelog, citation, fact sheet, and launch site to the published v1.0.4-alpha release
- record exact CI, native build, anonymous download, checksum, privacy, and security evidence
- retain v1.0.2 screenshots and video with explicit historical capture labels

## Verification
- 35 focused release, artifact, privacy, and community tests passed; 1 optional test skipped
- launch-site production build and desktop/mobile/interactions/media/links/accessibility QA passed
- privacy scan, npm audit, actionlint, Gitleaks history, and Gitleaks working-tree scans passed

No private paths, databases, local project details, or generated release downloads are included.