### PR TITLE
fix: repair capture schema during migration

### DIFF
--- a/rta_brain/capture_schema.py
+++ b/rta_brain/capture_schema.py
@@ -458,6 +458,7 @@ def capture_schema_v10_patch_required(conn: sqlite3.Connection) -> bool:
         "grant_id" not in _table_columns(conn, "capture_payloads")
         or "cutoff_at" not in _table_columns(conn, "capture_retention_runs")
         or not _table_exists(conn, "capture_event_content")
+        or bool(CAPTURE_INDEXES.difference(_object_names(conn, "index")))
     )
 
 

--- a/rta_brain/db.py
+++ b/rta_brain/db.py
@@ -951,6 +951,15 @@ def init_schema(
             from .federation_schema import migrate_federation_schema_v12
 
             migrate_federation_schema_v12(conn)
+        from .capture_schema import (
+            capture_schema_v10_patch_required,
+            upgrade_capture_schema_v10_patch,
+            validate_capture_schema_v10,
+        )
+
+        if capture_schema_v10_patch_required(conn):
+            upgrade_capture_schema_v10_patch(conn)
+        validate_capture_schema_v10(conn)
         from .federation_schema import validate_federation_schema_v12
 
         validate_federation_schema_v12(conn)

--- a/tests/test_v11a_lifecycle_security.py
+++ b/tests/test_v11a_lifecycle_security.py
@@ -101,6 +101,56 @@ def test_current_version_structural_patch_requires_backed_up_lifecycle(tmp_path)
     assert result["state"] == "complete"
 
 
+def test_missing_capture_index_requires_backed_up_lifecycle(tmp_path):
+    database, _root, request = _project(tmp_path)
+    raw = sqlite3.connect(database)
+    raw.execute("DROP INDEX idx_capture_events_project_privacy_sequence")
+    raw.commit()
+    raw.close()
+
+    blocked = plan_lifecycle(request, {"schema_policy": "current-only"})
+    assert blocked["blocked"] is True
+    assert "schema_migration_not_authorized" in blocked["blockers"]
+
+    plan = plan_lifecycle(request, {"schema_policy": "migrate-with-backup"})
+    result = apply_lifecycle(plan, _confirmation(plan))
+    assert result["state"] == "complete"
+
+    verify = sqlite3.connect(database)
+    try:
+        index = verify.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?",
+            ("idx_capture_events_project_privacy_sequence",),
+        ).fetchone()
+        assert index is not None
+    finally:
+        verify.close()
+
+
+def test_older_schema_migration_repairs_missing_capture_index(tmp_path):
+    database, _root, request = _project(tmp_path)
+    raw = sqlite3.connect(database)
+    raw.execute("DROP INDEX idx_capture_events_project_privacy_sequence")
+    raw.execute(f"PRAGMA user_version = {db.SCHEMA_VERSION - 1}")
+    raw.commit()
+    raw.close()
+
+    plan = plan_lifecycle(request, {"schema_policy": "migrate-with-backup"})
+    result = apply_lifecycle(plan, _confirmation(plan))
+    assert result["state"] == "complete"
+
+    verify = sqlite3.connect(database)
+    try:
+        assert verify.execute("PRAGMA user_version").fetchone()[0] == db.SCHEMA_VERSION
+        index = verify.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?",
+            ("idx_capture_events_project_privacy_sequence",),
+        ).fetchone()
+        assert index is not None
+    finally:
+        verify.close()
+
+
 def test_repair_requires_the_exact_previewed_plan(tmp_path):
     _database, _root, request = _project(tmp_path)
     initial = plan_lifecycle(request, {})


### PR DESCRIPTION
## Summary
- detect missing capture indexes as a schema patch requirement
- repair and validate capture schema inside supervised migrations
- cover current-schema and older-schema upgrade regressions

## Verification
- 24 focused lifecycle/capture tests passed
- full local suite: 1191 passed, 30 skipped, 704 subtests passed
- privacy scan passed
- Gitleaks found no leaks
- sealed Codex Security diff scan reported zero findings