### PR TITLE
release: prepare v1.1.0-alpha.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [1.1.0-alpha.3] - 2026-09-08
+
+- Repaired backup-gated upgrades when a capture-schema index is missing from an
+  otherwise supported older or current brain database.
+- Required capture-schema repair and validation to complete inside the same
+  supervised migration transaction before the runtime records the current
+  schema version.
+- Added regression coverage for current-schema repair and older-schema upgrade
+  recovery without weakening fail-closed migration authorization.
+- Moved independent coverage into the README opening viewport and added the
+  CodexWorkshop analysis beside The Next New Thing on the launch website.
+
+This maintenance prerelease retains the v1.1B capability boundary. It does not
+add a new product wave or change federation defaults.
+
 ## [1.1.0-alpha.2] - 2026-09-08
 
 - Added optional end-to-end encrypted federation between independent local project brains.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ type: software
 authors:
   - family-names: Dubey
     given-names: Sulabh
-version: 1.1.0-alpha.2
+version: 1.1.0-alpha.3
 license: MIT
 abstract: "Local-first project memory, repository graph, context packs, and MCP tools for AI coding agents. Conceived and researched by Sulabh Dubey; built with OpenAI Codex as the primary AI engineering agent under maintainer review."
 repository-code: "https://github.com/sulabhdubey/rta-smriti-brain"

--- a/README.md
+++ b/README.md
@@ -12,14 +12,16 @@ decisions, evidence, and the exact state needed to continue work without retelli
 [![Release](https://img.shields.io/github/v/release/sulabhdubey/rta-smriti-brain?include_prereleases&label=release)](https://github.com/sulabhdubey/rta-smriti-brain/releases)
 [![License: MIT](https://img.shields.io/badge/license-MIT-2ea44f.svg)](LICENSE)
 
-[**Install**](#ten-minute-start) | [**Current release**](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v1.1.0-alpha.2) | [**Live website**](https://sulabhdubey.github.io/rta-smriti-brain/) | [**Documentation**](#documentation) | [**Discussions**](https://github.com/sulabhdubey/rta-smriti-brain/discussions)
+[**Install**](#ten-minute-start) | [**Current release**](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v1.1.0-alpha.3) | [**Live website**](https://sulabhdubey.github.io/rta-smriti-brain/) | [**Documentation**](#documentation) | [**Discussions**](https://github.com/sulabhdubey/rta-smriti-brain/discussions)
+
+> **Independent coverage:** [CodexWorkshop research: Rta-Smriti keeps agent memory local](https://www.codexworkshop.com/research/rta-smriti-brain-keeps-agent-memory-local) | [Featured on The Next New Thing](https://www.youtube.com/watch?v=AWzzmrCPe-A&t=1350s)
 
 ## v1.1B Governed Federation
 
-**Current release: v1.1.0-alpha.2.** Trusted local operation now includes optional,
+**Current release: v1.1.0-alpha.3.** Trusted local operation now includes optional,
 end-to-end encrypted collaboration over selected project memory.
 
-> **Current maturity:** `v1.1.0-alpha.2` is an advanced early-adopter release for Windows,
+> **Current maturity:** `v1.1.0-alpha.3` is an advanced early-adopter release for Windows,
 > macOS, and Linux. It is useful for real projects, but it is not yet presented as a
 > broadly supported production platform. Read the bounded
 > [release verification record](docs/RELEASE_VERIFICATION.md).
@@ -185,7 +187,7 @@ sessions exist, and opens an authorized local console. Use `--no-continuity` on 
 without local Codex sessions.
 
 Prefer a standalone binary? Download the Windows, macOS, or Linux artifact and its SBOM
-from the [`v1.1.0-alpha.2` release](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v1.1.0-alpha.2),
+from the [`v1.1.0-alpha.3` release](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v1.1.0-alpha.3),
 then verify it against `SHA256SUMS.txt`.
 
 ## Private By Default
@@ -262,7 +264,7 @@ limits, and remaining external-host gates are recorded in
 | [Architecture](docs/ARCHITECTURE.md) | Identity, event journal, truth model, graph, compiler, lifecycle |
 | [MCP host matrix](docs/MCP_HOST_MATRIX.md) | Host recipes, capability profiles, and live-proof status |
 | [Public benchmark](docs/PUBLIC_BENCHMARK.md) | Reproducible retrieval harness and honest interpretation |
-| [Release notes](docs/RELEASE_NOTES_v1.1.0-alpha.2.md) | What changed in v1.1B |
+| [Release notes](docs/RELEASE_NOTES_v1.1.0-alpha.3.md) | v1.1B maintenance and schema-recovery fix |
 | [Release verification](docs/RELEASE_VERIFICATION.md) | Tests, artifacts, checksums, security evidence, and limits |
 | [Contributing](CONTRIBUTING.md) | A practical first contribution path |
 | [Roadmap](ROADMAP.md) | Planned product waves and boundaries |
@@ -279,8 +281,10 @@ Tried Rta-Smriti on a real project?
 - [Pick a first contribution](https://github.com/sulabhdubey/rta-smriti-brain/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 - [Star the repository](https://github.com/sulabhdubey/rta-smriti-brain) if it saved you from repeating project context
 
-Rta-Smriti was [featured on The Next New Thing](https://www.youtube.com/watch?v=AWzzmrCPe-A&t=1350s)
-in its GitHub repository roundup.
+Independent coverage:
+
+- [CodexWorkshop: Rta-Smriti keeps agent memory local](https://www.codexworkshop.com/research/rta-smriti-brain-keeps-agent-memory-local)
+- [The Next New Thing: Rta-Smriti segment](https://www.youtube.com/watch?v=AWzzmrCPe-A&t=1350s)
 
 ## Provenance And License
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -2,7 +2,7 @@
 
 ## Current Prerelease
 
-[`v1.1.0-alpha.2`](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v1.1.0-alpha.2)
+[`v1.1.0-alpha.3`](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v1.1.0-alpha.3)
 is the current public prerelease. Use the source checkout or download the
 standalone binary for your operating system from that release. Verify downloads
 against its `SHA256SUMS.txt` before execution.
@@ -67,7 +67,7 @@ The repository includes a reproducible PyInstaller specification. The release
 workflow builds and smoke-tests separate Windows, macOS, and Linux artifacts,
 renames them with version/OS/architecture, and uploads a `SHA256SUMS.txt`
 manifest. The current formal
-[`v1.1.0-alpha.2` release](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v1.1.0-alpha.2)
+[`v1.1.0-alpha.3` release](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v1.1.0-alpha.3)
 contains Windows x64, Linux x64, and macOS binaries, a universal wheel,
 CycloneDX SBOMs, and the combined checksum manifest.
 

--- a/docs/RELEASE_NOTES_v1.1.0-alpha.3.md
+++ b/docs/RELEASE_NOTES_v1.1.0-alpha.3.md
@@ -1,0 +1,52 @@
+# Rta-Smriti Brain v1.1.0-alpha.3
+
+Release wave: **v1.1B maintenance**
+Package metadata: `1.1.0a3`
+Maturity: **Alpha prerelease**
+
+Previous public release: v1.1.0-alpha.2
+
+Rta-Smriti Brain was conceived, researched, and product-directed by Sulabh
+Dubey. OpenAI Codex was the primary AI engineering agent under Sulabh's review
+and release approval.
+
+## Why This Maintenance Release Exists
+
+Dogfooding an existing private brain found a narrow upgrade defect: a database
+could report a supported schema version while one expected capture index was
+missing. The Trusted Lifecycle Supervisor correctly required backup-first migration,
+but the migration path did not repair and validate that index before recording
+the newer schema version.
+
+## What Changed
+
+- Missing capture indexes now make the structural capture patch explicitly
+  required.
+- Supported older-schema upgrades repair the capture structure in the same
+  supervised migration transaction.
+- Capture schema validation must pass before migration completion is recorded.
+- Current-schema structural repair remains gated by the existing
+  `migrate-with-backup` lifecycle policy.
+- Regression tests cover both a current-schema missing index and an older
+  schema carrying the same defect into an upgrade.
+
+## What Did Not Change
+
+- No automatic or silent database migration was introduced.
+- No downgrade, database rewriting, or bypass of backup authorization is
+  permitted.
+- Governed federation remains optional, encrypted, and disabled by default.
+- The v1.1B feature set, maturity claim, privacy boundary, and MCP capability
+  model are unchanged.
+
+## Upgrade Guidance
+
+Install `1.1.0a3` over an earlier release, then use the Trusted Lifecycle
+Supervisor to inspect and preview any required schema action. Approve
+`migrate-with-backup` only after reviewing the proposed backup and migration
+steps. The supervisor verifies the resulting database structure before it
+records migration completion.
+
+Exact hosted tests, security checks, artifacts, checksums, and publication
+receipts will be recorded in [Release Verification](RELEASE_VERIFICATION.md)
+after the immutable tag and public assets exist.

--- a/launch-assets/press/PRODUCT_FACT_SHEET.md
+++ b/launch-assets/press/PRODUCT_FACT_SHEET.md
@@ -2,7 +2,7 @@
 
 **Category:** Open-source developer tool, local AI project memory
 
-**Current public prerelease:** [`v1.1.0-alpha.2`](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v1.1.0-alpha.2) (`1.1.0a2` package metadata).
+**Current public prerelease:** [`v1.1.0-alpha.3`](https://github.com/sulabhdubey/rta-smriti-brain/releases/tag/v1.1.0-alpha.3) (`1.1.0a3` package metadata).
 
 **Release bundle:** SHA-256 checksums, a universal wheel, CycloneDX SBOMs, and standalone Windows, Linux, and macOS artifacts built and smoke-tested from the annotated v1 tag.
 

--- a/launch-site/src/main.jsx
+++ b/launch-site/src/main.jsx
@@ -28,12 +28,13 @@ import {
 import "./styles.css";
 
 const repositoryUrl = import.meta.env.VITE_REPOSITORY_URL || "https://github.com/sulabhdubey/rta-smriti-brain";
-const releaseUrl = `${repositoryUrl}/releases/tag/v1.1.0-alpha.2`;
-const releaseNotesUrl = `${repositoryUrl}/blob/main/docs/RELEASE_NOTES_v1.1.0-alpha.2.md`;
+const releaseUrl = `${repositoryUrl}/releases/tag/v1.1.0-alpha.3`;
+const releaseNotesUrl = `${repositoryUrl}/blob/main/docs/RELEASE_NOTES_v1.1.0-alpha.3.md`;
 const ciRunUrl = `${repositoryUrl}/actions/workflows/ci.yml`;
 const nativeRunUrl = `${repositoryUrl}/actions/workflows/binaries.yml`;
 const productHuntUrl = "https://www.producthunt.com/products/rta-smriti-brain?launch=rta-smriti-brain&utm_source=website&utm_medium=referral&utm_campaign=v11b_release";
 const featuredVideoUrl = "https://www.youtube.com/watch?v=AWzzmrCPe-A&t=1350s";
+const codexWorkshopUrl = "https://www.codexworkshop.com/research/rta-smriti-brain-keeps-agent-memory-local";
 
 
 const installCommands = {
@@ -133,11 +134,18 @@ function RecognitionBand() {
     <aside className="recognitionBand" aria-label="Independent coverage">
       <div className="shell recognitionInner">
         <span><CircleDot size={13} /> Independent coverage</span>
-        <a href={featuredVideoUrl} target="_blank" rel="noreferrer">
-          <strong>Featured on The Next New Thing</strong>
-          <small>Watch the Rta-Smriti segment</small>
-          <ExternalLink size={14} />
-        </a>
+        <div className="recognitionLinks">
+          <a href={codexWorkshopUrl} target="_blank" rel="noreferrer">
+            <strong>Research by CodexWorkshop</strong>
+            <small>Read the independent analysis</small>
+            <ExternalLink size={14} />
+          </a>
+          <a href={featuredVideoUrl} target="_blank" rel="noreferrer">
+            <strong>Featured on The Next New Thing</strong>
+            <small>Watch the Rta-Smriti segment</small>
+            <ExternalLink size={14} />
+          </a>
+        </div>
       </div>
     </aside>
   );

--- a/launch-site/src/styles.css
+++ b/launch-site/src/styles.css
@@ -68,6 +68,7 @@ img { display: block; max-width: 100%; }
 .recognitionInner { display: flex; align-items: center; justify-content: space-between; gap: 24px; min-height: 74px; }
 .recognitionInner > span { display: inline-flex; align-items: center; gap: 8px; color: #839bad; font-size: 10px; font-weight: 850; text-transform: uppercase; }
 .recognitionInner > span svg { color: var(--amber); }
+.recognitionLinks { display: flex; align-items: center; justify-content: flex-end; gap: 30px; }
 .recognitionInner a { display: flex; align-items: center; gap: 11px; color: #d9e9f4; }
 .recognitionInner a:hover { color: white; }
 .recognitionInner strong { font-size: 14px; }
@@ -190,6 +191,11 @@ footer { padding: 34px 0; background: #03070b; }
 .platformSwitch button[aria-selected="true"] { color: #021415; background: var(--teal); font-weight: 800; }
 @media (max-width: 860px) {
   :root { --shell: min(100% - 28px, 680px); }
+  .recognitionInner { align-items: flex-start; min-height: 0; padding-block: 18px; }
+  .recognitionInner > span { display: none; }
+  .recognitionLinks { display: grid; width: 100%; gap: 14px; }
+  .recognitionInner a { width: 100%; justify-content: space-between; }
+  .recognitionInner a small { margin-left: auto; }
   .siteNav { position: absolute; top: 66px; right: 14px; display: none; width: 230px; padding: 12px; border: 1px solid var(--line); border-radius: 7px; background: #08121c; }
   .siteNav.open { display: grid; }.siteNav a { padding: 9px; }.menuButton { display: grid; place-items: center; width: 38px; height: 38px; }
   .hero { min-height: 850px; }.heroImage { left: 8%; width: 120%; opacity: .48; }.heroScrim { background: rgba(3,8,13,.63); }
@@ -205,10 +211,6 @@ footer { padding: 34px 0; background: #03070b; }
 }
 
 @media (max-width: 560px) {
-  .recognitionInner { align-items: flex-start; min-height: 0; padding-block: 18px; }
-  .recognitionInner > span { display: none; }
-  .recognitionInner a { width: 100%; justify-content: space-between; }
-  .recognitionInner a small { margin-left: auto; }
   .heroProof { display: grid; grid-template-columns: repeat(3, 1fr); }.heroProof span { min-width: 0; }.heroProof strong { font-size: 14px; }.heroProof { font-size: 9px; }
   .heroActions { display: grid; }.frameCaption { position: static; max-width: none; border-width: 1px 0 0; border-radius: 0; }.productFrame { aspect-ratio: auto; }.productFrame img { aspect-ratio: 16/10; object-fit: cover; }.productFrame { overflow: visible; }
   .comparisonHead, .comparisonRow { gap: 10px; font-size: 11px; }.terminalBlock code { font-size: 10px; } .releaseTrack { grid-template-columns: 1fr; } .releaseTrack article { min-height: auto; border-right: 0; border-bottom: 1px solid var(--line); }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rta-smriti-brain-dashboard",
-  "version": "1.1.0-alpha.2",
+  "version": "1.1.0-alpha.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rta-smriti-brain-dashboard",
-      "version": "1.1.0-alpha.2",
+      "version": "1.1.0-alpha.3",
       "dependencies": {
         "lucide-react": "^0.468.0",
         "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rta-smriti-brain-dashboard",
-  "version": "1.1.0-alpha.2",
+  "version": "1.1.0-alpha.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rta-smriti-brain"
-version = "1.1.0a2"
+version = "1.1.0a3"
 description = "Local-first project memory, repo graph, context-pack, and MCP brain for AI coding agents."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/rta_brain/__init__.py
+++ b/rta_brain/__init__.py
@@ -1,3 +1,3 @@
 """Rta-Smriti local project brain."""
 
-__version__ = "1.1.0a2"
+__version__ = "1.1.0a3"

--- a/scripts/build_installed_smoke.py
+++ b/scripts/build_installed_smoke.py
@@ -20,8 +20,8 @@ from package_release_artifacts import (
 
 from rta_brain.repository import run_git_inspection
 
-BASELINE_REF = "v1.1.0-alpha"
-BASELINE_COMMIT = "90e0c93b57a2f76c8009fd70138e4f1107c98f57"
+BASELINE_REF = "v1.1.0-alpha.2"
+BASELINE_COMMIT = "39e77a9fdfb9639dfd4d8d82fc96ab92cd32fe4e"
 MAX_BASELINE_ARCHIVE_ENTRIES = 20_000
 MAX_BASELINE_ARCHIVE_BYTES = 256 * 1024 * 1024
 MAX_BASELINE_ENTRY_BYTES = 32 * 1024 * 1024

--- a/scripts/launch_site_qa.mjs
+++ b/scripts/launch_site_qa.mjs
@@ -92,7 +92,7 @@ try {
   assert.match(bodyText, /v1\.1B/i);
   assert.match(bodyText, /prerelease/i);
   const releaseLink = page.getByRole("link", { name: "Get current release", exact: true });
-  assert.match(await releaseLink.getAttribute("href"), /\/releases\/tag\/v1\.1\.0-alpha\.2$/);
+  assert.match(await releaseLink.getAttribute("href"), /\/releases\/tag\/v1\.1\.0-alpha\.3$/);
   assert.match(bodyText, /Universal Capture/);
   assert.match(bodyText, /Bitemporal/);
   assert.match(bodyText, /Context Compiler/i);
@@ -102,6 +102,11 @@ try {
   assert.equal(
     await featuredLink.getAttribute("href"),
     "https://www.youtube.com/watch?v=AWzzmrCPe-A&t=1350s",
+  );
+  const codexWorkshopLink = page.getByRole("link", { name: /Research by CodexWorkshop/i });
+  assert.equal(
+    await codexWorkshopLink.getAttribute("href"),
+    "https://www.codexworkshop.com/research/rta-smriti-brain-keeps-agent-memory-local",
   );
 
 
@@ -162,6 +167,11 @@ try {
     targets: violation.nodes.map((node) => node.target),
   }));
   assert.deepEqual(desktopViolations, []);
+
+  await page.setViewportSize({ width: 768, height: 1024 });
+  assert.ok((await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth)) <= 1);
+  await page.getByRole("link", { name: /Research by CodexWorkshop/i }).waitFor();
+  await page.getByRole("link", { name: /Featured on The Next New Thing/i }).waitFor();
 
   await page.setViewportSize({ width: 390, height: 844 });
   await page.getByRole("button", { name: "Open menu", exact: true }).click();

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -6,12 +6,12 @@ from pathlib import Path
 from rta_brain import __version__
 
 ROOT = Path(__file__).resolve().parents[1]
-EXPECTED_PYTHON_VERSION = "1.1.0a2"
-EXPECTED_DISPLAY_VERSION = "1.1.0-alpha.2"
-RELEASE_CANDIDATE = "v1.1.0-alpha.2"
+EXPECTED_PYTHON_VERSION = "1.1.0a3"
+EXPECTED_DISPLAY_VERSION = "1.1.0-alpha.3"
+RELEASE_CANDIDATE = "v1.1.0-alpha.3"
 PUBLISHED_CURRENT = RELEASE_CANDIDATE
-PUBLISHED_BASELINE = "v1.1.0-alpha"
-PUBLISHED_BASELINE_COMMIT = "90e0c93b57a2f76c8009fd70138e4f1107c98f57"
+PUBLISHED_BASELINE = "v1.1.0-alpha.2"
+PUBLISHED_BASELINE_COMMIT = "39e77a9fdfb9639dfd4d8d82fc96ab92cd32fe4e"
 
 
 class ReleaseMetadataTests(unittest.TestCase):
@@ -31,7 +31,7 @@ class ReleaseMetadataTests(unittest.TestCase):
         usage = (ROOT / "docs" / "USAGE_GUIDE.md").read_text(encoding="utf-8")
         architecture = (ROOT / "docs" / "ARCHITECTURE.md").read_text(encoding="utf-8")
         federation_guide = (ROOT / "docs" / "FEDERATION_GUIDE.md").read_text(encoding="utf-8")
-        release_notes = (ROOT / "docs" / "RELEASE_NOTES_v1.1.0-alpha.2.md").read_text(encoding="utf-8")
+        release_notes = (ROOT / "docs" / "RELEASE_NOTES_v1.1.0-alpha.3.md").read_text(encoding="utf-8")
         release_verification = (ROOT / "docs" / "RELEASE_VERIFICATION.md").read_text(encoding="utf-8")
         threat_model = (ROOT / "docs" / "security" / "v1.0-cognition-threat-model.md").read_text(encoding="utf-8")
 
@@ -53,14 +53,16 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertIn("## Published v1.0.0-alpha", roadmap)
         self.assertIn("## Published v0.9.1-alpha", roadmap)
         self.assertIn("## [1.1.0-alpha] - 2026-09-05", changelog)
-        self.assertIn("**Current public prerelease:** [`v1.1.0-alpha.2`]", fact_sheet)
+        self.assertIn("**Current public prerelease:** [`v1.1.0-alpha.3`]", fact_sheet)
         self.assertIn("**Release bundle:** SHA-256 checksums", fact_sheet)
         self.assertIn("## v1.1B Governed Federation", readme)
-        self.assertIn("Current release: v1.1.0-alpha.2", readme)
+        self.assertIn("Current release: v1.1.0-alpha.3", readme)
+        self.assertIn("CodexWorkshop research", readme)
         self.assertIn("Project Reality", launch_site)
         self.assertIn("project-reality-v1.1.0.png", launch_site)
         self.assertNotIn("Creator-Brief", readme + fact_sheet + launch_site)
-        self.assertIn("/releases/tag/v1.1.0-alpha.2", launch_site)
+        self.assertIn("/releases/tag/v1.1.0-alpha.3", launch_site)
+        self.assertIn("Research by CodexWorkshop", launch_site)
         self.assertIn("captured from v1.0.2", launch_site)
         self.assertIn("## v1.1B Governed Federation", roadmap)
         self.assertIn("## v1.1B Governed Federation", readme)


### PR DESCRIPTION
## Summary
- publish the backup-gated capture schema repair as a justified maintenance alpha
- align package, installation, release-note, README, fact-sheet, and launch-site metadata
- surface independent CodexWorkshop research and The Next New Thing coverage near the first viewport
- retain the v1.1B scope while updating installed upgrade and launch-site regression gates

## Verified locally
- 1191 tests passed, 30 skipped, 704 subtests passed
- focused release tests: 29 passed
- installed alpha.2 -> alpha.3 -> alpha.2 -> alpha.3 lifecycle passed
- dashboard and launch-site builds passed
- launch-site desktop, tablet, mobile, accessibility, links, media, and interaction QA passed
- npm audit: 0 vulnerabilities
- privacy scan passed
- Gitleaks found no leaks
- publish-readiness: ready

No private brain, transcript, local path, credential, or unpublished outreach artifact is included.