### PR TITLE
Harden concurrent brain reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,33 @@ The context compiler selects direct evidence before low-trust history, obeys exp
 token budgets and privacy grants, and emits a selection receipt explaining what was
 included and why.
 
+Search results report task-anchor relevance. If a named project or product anchor is
+missing, the quick context pack abstains and suppresses weakly overlapping evidence
+until the operator selects or registers the intended project brain.
+
+CLI and MCP context retrieval use validated query-only SQLite connections. Watcher,
+capture, and continuity workers enter one FIFO writer queue per brain. Queue tickets
+are atomically published and owner-private, stale tickets from terminated workers are
+removed, and the active operating-system lease is released automatically after a crash.
+Expired or cancelled waiters cannot enter the critical section. Repository and Codex
+session discovery run before their workers join the write turn; shutdown drains use a
+bounded final wait, while heartbeats remain responsive and oversized WALs are
+checkpointed in bounded turns. Optional local-model continuity compaction also runs
+outside the writer turn, then reacquires a bounded turn only to commit its unverified
+derived result. Shutdown preserves the deterministic checkpoint without waiting on
+optional model inference.
+An active SQLite transaction remains atomic and is not preempted. This keeps retrieval
+available during background learning without treating a read as a hidden database write.
+
+Integrations can assert that boundary explicitly with `search --json --read-only`.
+The JSON response includes `access.mode: read_only` and
+`access.writes_performed: false` as a stable machine-readable contract.
+When byte-identical sources exist in both current code and deployment/package
+mirrors, retrieval selects the current source path and collapses the mirrors.
+Query-only semantic retrieval loads Sentence Transformer models from the local cache
+only, and CLI output is normalized to UTF-8 so indexed Unicode remains printable on
+legacy Windows consoles.
+
 ### 4. Operate through one trustworthy boundary
 
 ```mermaid

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -148,11 +148,11 @@ Codex JSONL sessions enter through a separate continuity adapter. It reads sessi
 
 ## Storage
 
-Each brain is one SQLite database. Connections reject symbolic, reparse, and hard-linked database files; apply owner-only POSIX modes where available; disable SQLite trusted schema; and use WAL journaling, normal synchronous durability, foreign keys, and a bounded busy timeout. Concurrent agents can read while crash-safe writes remain transactional. Project settings, portable repository identity, canonical root binding, manifests, file hashes, chunks, FTS records, optional embedding vectors, memories, claim provenance, versioned checkpoints, governance records, workspace references, entities, edges, evidence, and recall receipts remain local.
+Each brain is one SQLite database. Connections reject symbolic, reparse, and hard-linked database files; require owner-private database directories and files; disable SQLite trusted schema; and use WAL journaling, normal synchronous durability, foreign keys, and a bounded busy timeout. Concurrent agents can read while background writers enter a private FIFO queue and retain transactional, crash-safe writes. Queue tickets are published atomically, stale waiter tickets are identity-checked and removed after process termination, and expired or cancelled waiters cannot enter the critical section. Project settings, portable repository identity, canonical root binding, manifests, file hashes, chunks, FTS records, optional embedding vectors, memories, claim provenance, versioned checkpoints, governance records, workspace references, entities, edges, evidence, and recall receipts remain local.
 
 ## Ingestion
 
-The walker rejects links, non-regular files, ignored folders, traversal overages, total-size overages, and sources above the project's configured cap. A stat manifest skips unchanged repositories. Filesystem events bypass metadata shortcuts and bind a content-hash read to the repository root, even when size and modification time were restored. Only changed files are parsed, chunked, indexed, and embedded. `watch-repo` runs this incremental path in the foreground. The `watcher` lifecycle command runs it in a detached per-project worker. Standard packages and standalone binaries include Watchdog filesystem events; portable polling remains an emergency fallback when the event backend cannot start. Fallback polling waits at least 30 seconds at 10,000 indexed files and 60 seconds at 50,000 files, and forces a full content verification at least every five minutes so same-stat changes cannot remain indefinitely invisible.
+The walker rejects links, non-regular files, ignored folders, traversal overages, total-size overages, and sources above the project's configured cap. A stat manifest skips unchanged repositories. Managed workers build that manifest before requesting a writer turn, and unchanged cycles never enter the queue. The write turn begins immediately before the atomic SQLite transaction; a transaction already in progress is deliberately not preempted. Filesystem events bypass metadata shortcuts and bind a content-hash read to the repository root, even when size and modification time were restored. Only changed files are parsed, chunked, indexed, and embedded. `watch-repo` runs this incremental path in the foreground. The `watcher` lifecycle command runs it in a detached per-project worker. Standard packages and standalone binaries include Watchdog filesystem events; portable polling remains an emergency fallback when the event backend cannot start. Fallback polling waits at least 30 seconds at 10,000 indexed files and 60 seconds at 50,000 files, and forces a full content verification at least every five minutes so same-stat changes cannot remain indefinitely invisible.
 
 Deep freshness uses SHA-256 values cached by project, absolute source path, size, and nanosecond modification time. `ingest-repo --force` bypasses the manifest and metadata shortcuts for an uncached re-read.
 
@@ -181,7 +181,7 @@ Unavailable or failed parsers fall back to regex and emit warnings in the ingest
 
 ## Retrieval
 
-FTS5 BM25 remains available on every project. The recommended bootstrap path enables hybrid ranking that combines lexical rank with local cosine similarity through the dependency-free feature-hash provider. Operators can select lexical-only retrieval or a Sentence Transformers adapter, which loads only when separately installed and selected.
+FTS5 BM25 remains available on every project. The recommended bootstrap path enables hybrid ranking that combines lexical rank with local cosine similarity through the dependency-free feature-hash provider. Operators can select lexical-only retrieval or a Sentence Transformers adapter, which loads only when separately installed and selected. Query-only CLI and MCP retrieval require that optional model to be present locally; they do not download or populate a model cache. Windows CLI streams are reconfigured to UTF-8 before rendering retrieved text.
 
 Context packs enforce a caller-selected token budget. Checkpoints and high-ranked `pratyaksha` evidence are considered first; lower-priority memories and chunks are omitted when needed, and the pack states when pruning occurred. Optional `tiktoken` provides model tokenization while the dependency-free path uses a conservative deterministic estimate.
 
@@ -260,4 +260,7 @@ The HTTP console binds only to loopback, requires a per-launch capability token,
 Optional continuity compaction calls Ollama only through a validated HTTP(S)
 loopback base URL. Inputs and outputs are redacted and bounded, failures preserve
 the deterministic checkpoint, source events remain append-only, and summaries
-are stored as unverified derived evidence rather than verified facts.
+are stored as unverified derived evidence rather than verified facts. Managed
+continuity performs model inference outside the database writer lease, then rejoins
+the FIFO queue for the atomic derived-event and checkpoint commit. Service shutdown
+preserves deterministic state without invoking optional model compaction.

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -221,6 +221,58 @@ The destination must be the same verified repository lineage, the backup path mu
 
 Paste the output into the agent chat, then ask the agent to do the task.
 
+The pack reports `Retrieval relevance`. When a distinctive task anchor is absent from
+the selected project and its evidence, it returns a `Retrieval Abstention` instead of
+presenting weak matches as guidance. Select the correct project brain, register and
+index a missing project, or refine the task before continuing. Raw `search` results
+expose the same state and reason under `retrieval.relevance`.
+
+CLI and MCP `search` and `context-pack` calls open the brain in SQLite query-only mode
+and do not append recall telemetry. The managed watcher, capture daemon, and continuity
+worker serialize their database write turns through one private FIFO queue and per-brain
+operating-system lease. Tickets become visible only after their complete payload is
+durable. A terminated worker loses the active lease automatically, and its stale queue
+ticket is removed by the next waiter. Deadlines and stop requests are checked before a
+waiter can enter the critical section, and service shutdown uses a bounded final drain.
+The watcher performs repository discovery and unchanged-manifest checks before joining
+the queue; continuity performs Codex session discovery before its write turn. Large
+filesystem scans therefore do not reserve the writer while preparing work. Once a SQLite
+write transaction starts it remains atomic and is not preempted; FIFO admission prevents
+repeated ingest cycles from overtaking already-waiting capture or continuity work. Writer connections
+use a five-second SQLite busy timeout, bounded automatic WAL checkpoints, and a passive
+maintenance checkpoint when the WAL exceeds 64 MiB. After all frames are reclaimed,
+maintenance makes a bounded truncation attempt; active readers defer that step safely
+to a later writer turn. An operator should still stop verified workers and take a
+validated backup before exceptional manual repair.
+
+When loopback-only Ollama continuity compaction is enabled, the managed worker prepares
+a bounded request during its capture turn, releases the writer lease, and performs model
+inference without blocking watcher or capture writers. It then joins the FIFO queue again
+for the short atomic checkpoint commit. Model failure preserves a deterministic unverified
+checkpoint, and service shutdown skips optional inference rather than extending the final
+database drain.
+
+External adapters can require and verify the read boundary with a stable JSON command:
+
+```powershell
+& $RtaBrain --db "$env:USERPROFILE\Documents\Rta-Smriti\brains\project-name.sqlite" search --json --read-only --project project-name --limit 5 "current release state"
+```
+
+The response includes `access.mode` set to `read_only` and
+`access.writes_performed` set to `false`. The flag is an explicit compatibility
+contract; ordinary CLI search remains query-only when the flag is omitted.
+Query-only Sentence Transformer retrieval uses only a model already present in the local
+cache. An operator-controlled ingestion or setup flow may initialize a selected model,
+but an MCP or CLI read never downloads one. CLI output is emitted as UTF-8, including on
+legacy Windows console code pages, so Unicode and BOM-bearing indexed text remain
+printable.
+
+Search also reports `retrieval.current_source_selection`. If byte-identical source
+hashes appear under current code and known deployment/package mirror directories,
+Rta-Smriti keeps the current source path and removes duplicate mirror paths from the
+candidate set. Deployment-only material remains searchable when no current-source
+copy exists.
+
 Good task examples:
 
 ```text

--- a/rta_brain/capture_daemon.py
+++ b/rta_brain/capture_daemon.py
@@ -21,10 +21,12 @@ from .capture import append_event, validate_capture_identifiers
 from .capture_adapters import normalize_capture_event
 from .capture_spool import CaptureSpool, SpoolError, source_token
 from .capture_types import CapturePolicy, NormalizedEvent
+from .db import bounded_wal_checkpoint
 from .repository import same_root
 from .runtime_control import (
     clear_control_files,
     create_secret,
+    database_writer_lease,
     detached_worker_bootstrap,
     now_iso,
     open_log,
@@ -735,6 +737,14 @@ def run_capture_worker(
         while not heartbeat_stop.wait(cadence):
             persist()
 
+    def report_writer_wait(waited: float) -> None:
+        state["writer_state"] = "waiting"
+        state["writer_wait_seconds"] = round(waited, 3)
+        persist()
+
+    def stopping_requested() -> bool:
+        return stop_event.is_set() or stop_requested(stop_file, label="capture")
+
     signal.signal(signal.SIGTERM, request_stop)
     signal.signal(signal.SIGINT, request_stop)
     offset = 0
@@ -745,21 +755,32 @@ def run_capture_worker(
             target=heartbeat, name="rta-capture-heartbeat", daemon=True
         )
         heartbeat_thread.start()
-        while not stop_event.is_set() and not stop_requested(
-            stop_file, label="capture"
-        ):
+        while not stopping_requested():
             try:
-                conn = db.connect(db_path)
-                try:
-                    result = capture_cycle(
-                        conn,
-                        db_path,
-                        max_events=batch_size,
-                        max_seconds=0.25,
-                        start_offset=offset,
+                with database_writer_lease(
+                    db_path,
+                    on_wait=report_writer_wait,
+                    stop_requested=stopping_requested,
+                ) as writer_receipt:
+                    state["writer_state"] = "active"
+                    state["writer_wait_seconds"] = round(
+                        float(writer_receipt["wait_seconds"]), 3
                     )
-                finally:
-                    conn.close()
+                    conn = db.connect(db_path)
+                    try:
+                        result = capture_cycle(
+                            conn,
+                            db_path,
+                            max_events=batch_size,
+                            max_seconds=0.25,
+                            start_offset=offset,
+                        )
+                        state["wal_checkpoint"] = bounded_wal_checkpoint(
+                            conn, db_path
+                        )
+                    finally:
+                        conn.close()
+                state["writer_state"] = "idle"
                 offset = int(result["next_offset"])
                 counters["cycles"] += 1
                 for key in (
@@ -782,10 +803,14 @@ def run_capture_worker(
                 state["last_error_class"] = (
                     None if not result["failures"] else "CaptureSourceError"
                 )
+            except InterruptedError:
+                state["writer_state"] = "idle"
+                break
             except Exception as exc:  # noqa: BLE001 - isolate one source cycle from the daemon
                 counters["cycles"] += 1
                 counters["failures"] += 1
                 counters["consecutive_failures"] += 1
+                state["writer_state"] = "error"
                 state["last_error_class"] = exc.__class__.__name__
             state.update(counters)
             state["last_cycle_at"] = now_iso()
@@ -799,17 +824,27 @@ def run_capture_worker(
         state["state"] = "draining"
         persist()
         for _ in range(1_000):
-            conn = db.connect(db_path)
             try:
-                result = capture_cycle(
-                    conn,
+                with database_writer_lease(
                     db_path,
-                    max_events=batch_size,
-                    max_seconds=0.25,
-                    start_offset=offset,
-                )
-            finally:
-                conn.close()
+                    timeout_seconds=2.0,
+                    on_wait=report_writer_wait,
+                ):
+                    conn = db.connect(db_path)
+                    try:
+                        result = capture_cycle(
+                            conn,
+                            db_path,
+                            max_events=batch_size,
+                            max_seconds=0.25,
+                            start_offset=offset,
+                        )
+                        state["wal_checkpoint"] = bounded_wal_checkpoint(conn, db_path)
+                    finally:
+                        conn.close()
+            except TimeoutError:
+                state["last_error_class"] = "WriterLeaseTimeout"
+                break
             offset = int(result["next_offset"])
             for key in (
                 "events_inserted",

--- a/rta_brain/cli.py
+++ b/rta_brain/cli.py
@@ -101,6 +101,7 @@ from .continuity_daemon import (
 )
 from .db import (
     connect,
+    connect_readonly,
     doctor,
     get_project_settings,
     graph,
@@ -1161,6 +1162,11 @@ def build_parser() -> argparse.ArgumentParser:
     search_cmd.add_argument("query")
     search_cmd.add_argument("--project")
     search_cmd.add_argument("--limit", type=int, default=8)
+    search_cmd.add_argument(
+        "--read-only",
+        action="store_true",
+        help="Require the query-only search contract; search is always read-only",
+    )
 
     graph_cmd = sub.add_parser("graph", help="Read the local entity graph")
     add_common_options(graph_cmd)
@@ -2073,7 +2079,20 @@ def build_mcp_config(db_path: str, project: str, name: str) -> dict:
     return mcp_config_payload(db_path, project, name, tool_root())
 
 
+def _configure_utf8_output() -> None:
+    """Keep retrieved Unicode printable through legacy Windows code pages."""
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if (
+            callable(reconfigure)
+            and str(getattr(stream, "encoding", "")).lower().replace("-", "")
+            != "utf8"
+        ):
+            reconfigure(encoding="utf-8", errors="backslashreplace")
+
+
 def main(argv=None) -> int:
+    _configure_utf8_output()
     parser = build_parser()
     args = parser.parse_args(argv)
     if args.command == "start":
@@ -2646,7 +2665,12 @@ def main(argv=None) -> int:
     exit_code = 0
     conn = None
     try:
-        conn = connect(Path(args.db))
+        connection_factory = (
+            connect_readonly
+            if args.command in {"search", "context-pack"}
+            else connect
+        )
+        conn = connection_factory(Path(args.db))
         with conn:
             if args.command == "capture":
                 payload = _dispatch_capture(args, conn)
@@ -2714,7 +2738,17 @@ def main(argv=None) -> int:
             elif args.command == "ingest-thread":
                 payload = ingest_thread(conn, Path(args.path), project=args.project, title=args.title)
             elif args.command == "search":
-                payload = search(conn, args.query, project=args.project, limit=args.limit)
+                payload = search(
+                    conn,
+                    args.query,
+                    project=args.project,
+                    limit=args.limit,
+                    record_recall=False,
+                )
+                payload["access"] = {
+                    "mode": "read_only",
+                    "writes_performed": False,
+                }
             elif args.command == "graph":
                 payload = graph(conn, project=args.project, limit=args.limit)
             elif args.command == "graph-query":

--- a/rta_brain/context.py
+++ b/rta_brain/context.py
@@ -2,9 +2,13 @@ import copy
 import json
 import math
 
-from .db import indexed_freshness, latest_checkpoint, search
+from .db import (
+    indexed_freshness,
+    latest_checkpoint,
+    retrieval_relevance,
+    search,
+)
 from .repository import repository_state
-
 
 PRAMANA_PRIORITY = {"pratyaksha": 5, "sabda": 4, "anumana": 3, "smriti": 2, "kalpana": 1}
 PRIVACY_RANKS = {"public": 0, "internal": 1, "sensitive": 2, "restricted": 3}
@@ -89,11 +93,18 @@ def build_context_pack(
     if not 256 <= int(max_tokens) <= 100_000:
         raise ValueError("max_tokens must be between 256 and 100,000")
     results = filter_search_results_by_privacy(
-        search(conn, task, project=project, limit=limit),
+        search(
+            conn,
+            task,
+            project=project,
+            limit=limit,
+            record_recall=False,
+        ),
         privacy_ceiling,
     )
     selected_ceiling = _privacy_class(privacy_ceiling)
     public_projection = selected_ceiling == "public"
+    relevance = retrieval_relevance(task, project, results)
     stale = {} if public_projection else indexed_freshness(conn, project=project)
     stale_status = stale.get("state", "unknown")
     project_row = None if public_projection else conn.execute(
@@ -112,6 +123,8 @@ def build_context_pack(
         "",
         f"Project: {project}",
         f"Task: {_bounded_text(task, 600)}",
+        f"Retrieval relevance: {relevance['state']}",
+        f"Retrieval reason: {relevance['reason']}",
     ]
     if not public_projection:
         lines[3:3] = [
@@ -122,6 +135,19 @@ def build_context_pack(
             f"Index state: {stale_status}",
             f"stale status: {stale_status}",
         ])
+    if relevance["state"] == "insufficient":
+        missing = ", ".join(relevance["missing_distinctive_terms"]) or "none"
+        lines.extend(
+            [
+                "",
+                "## Retrieval Abstention",
+                f"- Missing distinctive task anchors: {missing}",
+                "- Do not use this context pack to guide edits or operational decisions.",
+                "- Verify the selected project bank, register and index the intended project, then retrieve a fresh context pack.",
+                "- Weakly overlapping evidence was suppressed to prevent cross-project drift.",
+            ]
+        )
+        return "\n".join(lines) + "\n"
     if git["is_git_repo"]:
         lines.append(f"Git snapshot: {git['branch']} @ {git['head']} | repository root: {git['repository_root']}")
     if not public_projection:

--- a/rta_brain/continuity_daemon.py
+++ b/rta_brain/continuity_daemon.py
@@ -24,8 +24,16 @@ from .continuity import (
     json_nesting_exceeds,
     reject_windows_network_path,
 )
-from .db import connect, ensure_project, get_project_settings, now_iso, save_checkpoint
+from .db import (
+    bounded_wal_checkpoint,
+    connect,
+    ensure_project,
+    get_project_settings,
+    now_iso,
+    save_checkpoint,
+)
 from .runtime_control import (
+    database_writer_lease,
     detached_worker_bootstrap,
     process_identity,
     runtime_executable,
@@ -823,6 +831,8 @@ def _checkpoint_for_session(
     *,
     inactive: bool = False,
     trigger_override: str | None = None,
+    defer_model_compaction: bool = False,
+    skip_model_compaction: bool = False,
 ) -> dict | None:
     init_continuity_schema(conn)
     project_id = ensure_project(conn, project)
@@ -876,24 +886,78 @@ def _checkpoint_for_session(
         gap += " Earlier transcript history was intentionally truncated during bounded recovery and requires explicit operator acknowledgement."
     settings = get_project_settings(conn, project)
     compaction = None
+    compaction_note = ""
+    candidate = {
+        "project": project,
+        "project_id": project_id,
+        "session_id": session_id,
+        "event_id": int(event["id"]),
+        "trigger": trigger,
+        "objective": objective,
+        "gap": gap,
+    }
     if settings.get("compaction_provider") == "ollama":
         compactable = [
             {"event_type": row["event_type"], "payload": json.loads(row["payload_json"])}
             for row in rows[-250:]
             if row["event_type"] in {"message", "tool_event", "agent_event", "history_truncated"}
         ]
-        try:
-            compaction = compact_session_events(
-                compactable,
-                model=str(settings["compaction_model"]),
-                endpoint=str(settings["compaction_endpoint"]),
-                timeout_seconds=float(settings["compaction_timeout_seconds"]),
+        if defer_model_compaction:
+            candidate["compaction_request"] = {
+                "events": compactable,
+                "model": str(settings["compaction_model"]),
+                "endpoint": str(settings["compaction_endpoint"]),
+                "timeout_seconds": float(settings["compaction_timeout_seconds"]),
+            }
+            return {"status": "deferred", "_deferred_checkpoint": candidate}
+        if skip_model_compaction:
+            compaction_note = (
+                " Local-model compaction was deferred during shutdown; "
+                "the deterministic checkpoint was preserved."
             )
+        else:
+            try:
+                compaction = compact_session_events(
+                    compactable,
+                    model=str(settings["compaction_model"]),
+                    endpoint=str(settings["compaction_endpoint"]),
+                    timeout_seconds=float(settings["compaction_timeout_seconds"]),
+                )
+            except Exception:  # noqa: BLE001 - optional compaction must not erase deterministic state
+                compaction_note = " Local-model compaction was unavailable; the deterministic checkpoint was preserved."
+    return _save_checkpoint_candidate(
+        conn,
+        candidate,
+        compaction=compaction,
+        compaction_note=compaction_note,
+    )
+
+
+def _save_checkpoint_candidate(
+    conn,
+    candidate: dict,
+    *,
+    compaction: dict | None = None,
+    compaction_note: str = "",
+) -> dict | None:
+    project = str(candidate["project"])
+    project_id = int(candidate["project_id"])
+    session_id = str(candidate["session_id"])
+    event_id = int(candidate["event_id"])
+    marked = conn.execute(
+        "SELECT 1 FROM continuity_checkpoint_marks WHERE project_id = ? AND session_id = ? AND event_id = ?",
+        (project_id, session_id, event_id),
+    ).fetchone()
+    if marked:
+        return None
+    gap = str(candidate["gap"])
+    if compaction is not None:
+        try:
             append_event(
                 conn,
                 project,
                 session_id,
-                f"compaction:{int(event['id'])}:{settings['compaction_model']}",
+                f"compaction:{event_id}:{compaction['model']}",
                 "continuity_compaction",
                 compaction,
                 source="ollama-local",
@@ -902,32 +966,80 @@ def _checkpoint_for_session(
                 _project_id=project_id,
             )
             gap += f" Local-model summary (unverified): {compaction['summary'][:4_000]}"
-        except Exception:  # noqa: BLE001 - optional compaction must not erase deterministic state
-            gap += " Local-model compaction was unavailable; the deterministic checkpoint was preserved."
+        except Exception:
+            conn.rollback()
+            raise
+    gap += compaction_note
     try:
         result = save_checkpoint(
             conn,
             project,
-            objective,
+            str(candidate["objective"]),
             verified_evidence="",
             remaining_gaps=gap,
             next_action="Review the captured session events, reconcile work state, and continue from verified evidence.",
             prohibited_repetition="",
             source="continuity-daemon",
-            trigger=trigger,
+            trigger=str(candidate["trigger"]),
             session_id=session_id,
             _commit=False,
         )
         checkpoint_id = int(result["checkpoint"]["id"])
         conn.execute(
             "INSERT INTO continuity_checkpoint_marks(project_id, session_id, event_id, checkpoint_id, trigger, created_at) VALUES (?, ?, ?, ?, ?, ?)",
-            (project_id, session_id, int(event["id"]), checkpoint_id, trigger, now_iso()),
+            (project_id, session_id, event_id, checkpoint_id, str(candidate["trigger"]), now_iso()),
         )
         conn.commit()
     except Exception:
         conn.rollback()
         raise
     return result
+
+
+def _complete_deferred_checkpoint(
+    db_path: Path,
+    project: str,
+    candidate: dict,
+    *,
+    timeout_seconds: float = 30.0,
+    stop_requested: Callable[[], bool] | None = None,
+    on_wait: Callable[[float], None] | None = None,
+) -> dict:
+    request = dict(candidate["compaction_request"])
+    compaction = None
+    compaction_note = ""
+    try:
+        compaction = compact_session_events(
+            list(request["events"]),
+            model=str(request["model"]),
+            endpoint=str(request["endpoint"]),
+            timeout_seconds=float(request["timeout_seconds"]),
+        )
+    except Exception:  # noqa: BLE001 - deterministic checkpoint still commits
+        compaction_note = " Local-model compaction was unavailable; the deterministic checkpoint was preserved."
+
+    with database_writer_lease(
+        db_path,
+        timeout_seconds=timeout_seconds,
+        stop_requested=stop_requested,
+        on_wait=on_wait,
+    ) as writer_receipt:
+        conn = connect(db_path)
+        try:
+            result = _save_checkpoint_candidate(
+                conn,
+                candidate,
+                compaction=compaction,
+                compaction_note=compaction_note,
+            )
+            wal_checkpoint = bounded_wal_checkpoint(conn, db_path)
+        finally:
+            conn.close()
+    return {
+        "created": result is not None,
+        "writer_wait_seconds": float(writer_receipt["wait_seconds"]),
+        "wal_checkpoint": wal_checkpoint,
+    }
 
 
 def capture_cycle(
@@ -946,7 +1058,11 @@ def capture_cycle(
     stop_requested: Callable[[], bool] | None = None,
     session_inventory: list[dict[str, str]] | None = None,
     on_sessions_discovered: Callable[[list[dict[str, str]]], None] | None = None,
+    defer_model_compaction: bool = False,
+    skip_model_compaction: bool = False,
 ) -> dict:
+    if defer_model_compaction and skip_model_compaction:
+        raise ValueError("model compaction cannot be deferred and skipped in the same cycle")
     init_continuity_schema(conn)
     current_time = time.time() if now is None else float(now)
     sessions = (
@@ -969,6 +1085,7 @@ def capture_cycle(
             "events_inserted": 0,
             "checkpoints_created": 0,
             "errors": [],
+            "_deferred_checkpoints": [],
         }
     if on_sessions_discovered is not None:
         on_sessions_discovered(sessions)
@@ -991,6 +1108,7 @@ def capture_cycle(
     inserted = 0
     checkpoints = 0
     errors = []
+    deferred_checkpoints = []
     for item in selected:
         if stop_requested is not None and stop_requested():
             return {
@@ -1001,6 +1119,7 @@ def capture_cycle(
                 "events_inserted": inserted,
                 "checkpoints_created": checkpoints,
                 "errors": errors,
+                "_deferred_checkpoints": deferred_checkpoints,
             }
         path = Path(item["path"])
         try:
@@ -1016,12 +1135,16 @@ def capture_cycle(
             is_latest = item["path"] == latest_path
             inactive = is_latest and current_time - path.stat().st_mtime >= max(1.0, float(inactivity_seconds))
             if is_latest and result["complete"]:
-                checkpoints += int(
-                    _checkpoint_for_session(
-                        conn, project, item["session_id"], inactive=inactive,
-                        trigger_override=checkpoint_trigger,
-                    ) is not None
+                checkpoint_result = _checkpoint_for_session(
+                    conn, project, item["session_id"], inactive=inactive,
+                    trigger_override=checkpoint_trigger,
+                    defer_model_compaction=defer_model_compaction,
+                    skip_model_compaction=skip_model_compaction,
                 )
+                if checkpoint_result and "_deferred_checkpoint" in checkpoint_result:
+                    deferred_checkpoints.append(checkpoint_result["_deferred_checkpoint"])
+                else:
+                    checkpoints += int(checkpoint_result is not None)
         except Exception as exc:  # noqa: BLE001 - isolate one malformed session from the batch
             conn.rollback()
             errors.append({"session_id": item["session_id"], "type": exc.__class__.__name__, "message": str(exc)})
@@ -1033,6 +1156,7 @@ def capture_cycle(
         "events_inserted": inserted,
         "checkpoints_created": checkpoints,
         "errors": errors,
+        "_deferred_checkpoints": deferred_checkpoints,
     }
 
 
@@ -1107,6 +1231,11 @@ def run_continuity_worker(
         while not heartbeat_stop.wait(cadence):
             persist_state()
 
+    def report_writer_wait(waited: float) -> None:
+        state["writer_state"] = "waiting"
+        state["writer_wait_seconds"] = round(waited, 3)
+        persist_state()
+
     signal.signal(signal.SIGTERM, request_stop)
     signal.signal(signal.SIGINT, request_stop)
     try:
@@ -1117,18 +1246,60 @@ def run_continuity_worker(
         stopped_during_cycle = False
         while not stopping_requested():
             try:
-                conn = connect(db_path)
-                try:
-                    result = capture_cycle(
-                        conn, sessions_root, project_root, project,
-                        inactivity_seconds=inactivity_seconds,
-                        lookback_days=lookback_days,
-                        backlog_tail_bytes=backlog_tail_bytes,
-                        stop_requested=stopping_requested,
-                        on_sessions_discovered=remember_session_inventory,
+                session_inventory = discover_codex_sessions(
+                    sessions_root,
+                    project_root,
+                    lookback_days=lookback_days,
+                    stop_requested=stopping_requested,
+                )
+                remember_session_inventory(session_inventory)
+                if stopping_requested():
+                    stopped_during_cycle = True
+                    break
+                with database_writer_lease(
+                    db_path,
+                    on_wait=report_writer_wait,
+                    stop_requested=stopping_requested,
+                ) as writer_receipt:
+                    state["writer_state"] = "active"
+                    state["writer_wait_seconds"] = round(
+                        float(writer_receipt["wait_seconds"]), 3
                     )
-                finally:
-                    conn.close()
+                    conn = connect(db_path)
+                    try:
+                        result = capture_cycle(
+                            conn, sessions_root, project_root, project,
+                            inactivity_seconds=inactivity_seconds,
+                            lookback_days=lookback_days,
+                            backlog_tail_bytes=backlog_tail_bytes,
+                            stop_requested=stopping_requested,
+                            session_inventory=session_inventory,
+                            defer_model_compaction=True,
+                        )
+                        state["wal_checkpoint"] = bounded_wal_checkpoint(
+                            conn, db_path
+                        )
+                    finally:
+                        conn.close()
+                state["writer_state"] = "idle"
+                deferred_checkpoints = result.pop("_deferred_checkpoints", [])
+                for candidate in deferred_checkpoints:
+                    if stopping_requested():
+                        stopped_during_cycle = True
+                        break
+                    completed = _complete_deferred_checkpoint(
+                        db_path,
+                        project,
+                        candidate,
+                        stop_requested=stopping_requested,
+                        on_wait=report_writer_wait,
+                    )
+                    state["writer_state"] = "idle"
+                    state["writer_wait_seconds"] = round(
+                        float(completed["writer_wait_seconds"]), 3
+                    )
+                    state["wal_checkpoint"] = completed["wal_checkpoint"]
+                    result["checkpoints_created"] += int(completed["created"])
                 counters["cycles"] += 1
                 counters["sessions_discovered"] = int(result["sessions_discovered"])
                 counters["sessions_pending"] = int(result["sessions_pending"])
@@ -1143,17 +1314,20 @@ def run_continuity_worker(
                     state["last_checkpoint_at"] = state["last_cycle_at"]
                 state["last_error"] = result["errors"][-1]["message"] if result["errors"] else None
                 stopped_during_cycle = result["status"] == "stopping"
+            except InterruptedError:
+                state["writer_state"] = "idle"
+                stopped_during_cycle = True
+                break
             except Exception as exc:  # noqa: BLE001 - daemon records and survives cycle failures
                 counters["errors"] += 1
                 counters["consecutive_errors"] += 1
+                state["writer_state"] = "error"
                 state["last_error"] = f"{exc.__class__.__name__}: {exc}"
             state.update(counters)
             persist_state()
             if stopped_during_cycle:
                 break
             stop_event.wait(timeout=float(interval_seconds))
-        heartbeat_stop.set()
-        heartbeat_thread.join(timeout=10)
         try:
             if stopped_during_cycle or last_session_inventory is None:
                 final_result = {
@@ -1162,18 +1336,28 @@ def run_continuity_worker(
                     "errors": [],
                 }
             else:
-                conn = connect(db_path)
-                try:
-                    final_result = capture_cycle(
-                        conn, sessions_root, project_root, project,
-                        inactivity_seconds=inactivity_seconds,
-                        checkpoint_trigger="service_shutdown",
-                        lookback_days=lookback_days,
-                        backlog_tail_bytes=backlog_tail_bytes,
-                        session_inventory=last_session_inventory,
-                    )
-                finally:
-                    conn.close()
+                with database_writer_lease(
+                    db_path,
+                    timeout_seconds=2.0,
+                    on_wait=report_writer_wait,
+                ):
+                    conn = connect(db_path)
+                    try:
+                        final_result = capture_cycle(
+                            conn, sessions_root, project_root, project,
+                            inactivity_seconds=inactivity_seconds,
+                            checkpoint_trigger="service_shutdown",
+                            lookback_days=lookback_days,
+                            backlog_tail_bytes=backlog_tail_bytes,
+                            session_inventory=last_session_inventory,
+                            skip_model_compaction=True,
+                        )
+                        final_result.pop("_deferred_checkpoints", None)
+                        state["wal_checkpoint"] = bounded_wal_checkpoint(
+                            conn, db_path
+                        )
+                    finally:
+                        conn.close()
             counters["events_inserted"] += int(final_result["events_inserted"])
             counters["checkpoints_created"] += int(final_result["checkpoints_created"])
             counters["errors"] += len(final_result["errors"])
@@ -1184,6 +1368,8 @@ def run_continuity_worker(
             counters["errors"] += 1
             state["last_error"] = f"{exc.__class__.__name__}: {exc}"
             state.update(counters)
+        heartbeat_stop.set()
+        heartbeat_thread.join(timeout=10)
         state["state"] = "stopping"
         persist_state()
         return 0

--- a/rta_brain/db.py
+++ b/rta_brain/db.py
@@ -73,6 +73,13 @@ QUERY_STOP_WORDS = {
     "code", "explain", "file", "files", "focused", "next", "prepare",
     "safest", "step", "task",
 }
+GENERIC_TASK_TERMS = {
+    "add", "analyze", "begin", "build", "check", "complete", "continue", "create",
+    "diagnose", "document", "edit", "evaluate", "find", "fix", "generate", "give",
+    "help", "implement", "improve", "inspect", "investigate", "list", "make", "open",
+    "plan", "publish", "remove", "research", "review", "resume", "run", "show",
+    "summarize", "test", "update", "use", "verify",
+}
 
 
 def now_iso() -> str:
@@ -240,6 +247,46 @@ def _prepare_database_path(db_path: Path) -> Path:
     return resolved
 
 
+def _existing_database_path(db_path: Path) -> Path:
+    """Validate an existing private brain without creating or hardening anything."""
+
+    requested = Path(db_path).expanduser()
+    if requested.is_symlink():
+        raise ValueError(f"brain database must not be a linked file: {requested}")
+    resolved = requested.resolve()
+    parent = resolved.parent
+    if not parent.is_dir() or parent.is_symlink() or _is_reparse_point(parent):
+        raise ValueError(f"brain database directory is not a safe directory: {parent}")
+    try:
+        database_info = resolved.lstat()
+    except OSError as exc:
+        raise ValueError(f"read-only access requires an existing brain database: {resolved}") from exc
+    if (
+        not stat.S_ISREG(database_info.st_mode)
+        or resolved.is_symlink()
+        or _is_reparse_point(resolved)
+        or database_info.st_nlink != 1
+    ):
+        raise ValueError(f"brain database must be an existing unlinked regular file: {resolved}")
+    if os.name == "nt":
+        _validate_windows_private(parent)
+        _validate_windows_private(resolved)
+    else:
+        _validate_posix_private_directory(parent)
+        if database_info.st_uid != os.getuid() or stat.S_IMODE(database_info.st_mode) & 0o077:
+            raise PermissionError(f"brain database must be private and owned by the current user: {resolved}")
+    _validate_database_sidecars(resolved, harden=False)
+    return resolved
+
+
+def _validate_posix_private_directory(path: Path) -> None:
+    details = path.stat()
+    if details.st_uid != os.getuid() or stat.S_IMODE(details.st_mode) & 0o077:
+        raise PermissionError(
+            f"brain database directory must be private and owned by the current user: {path}"
+        )
+
+
 def _newer_schema_error(observed_version: int) -> ValueError:
     return ValueError(
         "brain database uses newer schema version "
@@ -276,6 +323,8 @@ def connect(db_path: Path) -> sqlite3.Connection:
                         raise
                     time.sleep(0.02)
         conn.execute("PRAGMA synchronous = NORMAL")
+        conn.execute("PRAGMA wal_autocheckpoint = 4096")
+        conn.execute("PRAGMA journal_size_limit = 67108864")
         conn.execute("PRAGMA trusted_schema = OFF")
         if _database_identity(database) != identity_before_open:
             raise ValueError("brain database changed identity during initialization")
@@ -296,6 +345,81 @@ def connect(db_path: Path) -> sqlite3.Connection:
         _ensure_posix_private_mode(database, 0o600)
         _validate_database_sidecars(database, harden=True)
     return conn
+
+
+def connect_readonly(db_path: Path) -> sqlite3.Connection:
+    """Open a validated query-only connection without mutating database state."""
+
+    database = _existing_database_path(db_path)
+    identity_before_open = _database_identity(database)
+    conn = sqlite3.connect(f"{database.as_uri()}?mode=ro", uri=True)
+    try:
+        if _database_identity(database) != identity_before_open:
+            raise ValueError("brain database changed identity while it was being opened read-only")
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA busy_timeout = 5000")
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute("PRAGMA recursive_triggers = ON")
+        conn.execute("PRAGMA query_only = ON")
+        conn.execute("PRAGMA trusted_schema = OFF")
+        schema_version = int(conn.execute("PRAGMA user_version").fetchone()[0])
+        if schema_version > SCHEMA_VERSION:
+            raise _newer_schema_error(schema_version)
+        _validate_database_sidecars(database, harden=False)
+        if _database_identity(database) != identity_before_open:
+            raise ValueError("brain database changed identity during read-only initialization")
+        return conn
+    except Exception:
+        conn.close()
+        raise
+
+
+def bounded_wal_checkpoint(
+    conn: sqlite3.Connection,
+    db_path: Path,
+    *,
+    threshold_bytes: int = 64 * 1024 * 1024,
+) -> dict[str, int | bool | str]:
+    """Passively checkpoint a large WAL without blocking active readers."""
+
+    if conn.in_transaction:
+        raise ValueError("cannot checkpoint WAL inside an active transaction")
+    wal_path = Path(f"{Path(db_path).expanduser().resolve()}-wal")
+    before = wal_path.stat().st_size if wal_path.is_file() else 0
+    if before < max(0, int(threshold_bytes)):
+        return {
+            "attempted": False,
+            "mode": "passive",
+            "bounded": before <= max(0, int(threshold_bytes)),
+            "busy": 0,
+            "log_frames": 0,
+            "checkpointed_frames": 0,
+            "before_bytes": before,
+            "remaining_bytes": before,
+        }
+    busy, log_frames, checkpointed_frames = (
+        int(value) for value in conn.execute("PRAGMA wal_checkpoint(PASSIVE)").fetchone()
+    )
+    mode = "passive"
+    truncate_busy = 0
+    if busy == 0 and checkpointed_frames == log_frames:
+        truncate_busy, _truncate_log, _truncate_checkpointed = (
+            int(value)
+            for value in conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+        )
+        mode = "passive+truncate"
+    remaining = wal_path.stat().st_size if wal_path.is_file() else 0
+    return {
+        "attempted": True,
+        "mode": mode,
+        "bounded": remaining <= max(0, int(threshold_bytes)),
+        "busy": busy,
+        "truncate_busy": truncate_busy,
+        "log_frames": log_frames,
+        "checkpointed_frames": checkpointed_frames,
+        "before_bytes": before,
+        "remaining_bytes": remaining,
+    }
 
 
 def _execute_schema_statements(conn: sqlite3.Connection, script: str) -> None:
@@ -1950,8 +2074,12 @@ def _ingest_repo_impl(
     allow_root_rebind: bool = False,
     root_rebind_capability=None,
     changed_paths=None,
+    writer_lease_factory=None,
+    writer_lease_state=None,
+    initialize_schema: bool = True,
 ) -> dict:
-    init_schema(conn)
+    if initialize_schema:
+        init_schema(conn)
     root = root.resolve()
     if not root.exists() or not root.is_dir():
         raise ValueError(f"repo path does not exist or is not a directory: {root}")
@@ -1964,23 +2092,26 @@ def _ingest_repo_impl(
     pending_rebind = False
     requested_repository_identity = repository_identity(root)
     requested_checkout_identity = checkout_identity(root)
-    if existing_project and existing_project["root_path"] and not same_root(existing_project["root_path"], root):
-        stored_repository_identity = existing_project["repository_identity"]
-        if (
-            stored_repository_identity
-            and not _repository_identities_match(stored_repository_identity, requested_repository_identity, root)
-        ):
-            raise ValueError(
-                f"canonical root mismatch; repository identity mismatch for project '{project}': the requested checkout "
-                "does not match the brain's bound repository"
-            )
-        if not allow_root_rebind or root_rebind_capability is not _ROOT_REBIND_CAPABILITY:
-            raise ValueError(
-                f"canonical root mismatch for project '{project}'; use root-rebind so a backup and atomic reindex "
-                "are required"
-            )
+    if existing_project and existing_project["root_path"]:
+        if not same_root(existing_project["root_path"], root):
+            stored_repository_identity = existing_project["repository_identity"]
+            if (
+                stored_repository_identity
+                and not _repository_identities_match(stored_repository_identity, requested_repository_identity, root)
+            ):
+                raise ValueError(
+                    f"canonical root mismatch; repository identity mismatch for project '{project}': the requested "
+                    "checkout does not match the brain's bound repository"
+                )
+            if not allow_root_rebind or root_rebind_capability is not _ROOT_REBIND_CAPABILITY:
+                raise ValueError(
+                    f"canonical root mismatch for project '{project}'; use root-rebind so a backup and atomic reindex "
+                    "are required"
+                )
+            pending_rebind = True
         project_id = int(existing_project["id"])
-        pending_rebind = True
+    elif writer_lease_factory is not None:
+        raise ValueError("managed ingestion requires an enrolled project")
     else:
         project_id = ensure_project(conn, project, str(root), allow_root_rebind=allow_root_rebind)
     scan_binding_row = conn.execute(
@@ -2038,6 +2169,12 @@ def _ingest_repo_impl(
             "parser_adapter": parser_adapter, "embedding_provider": embedding_provider_name,
             "parser_warnings": [], "manifest_unchanged": True,
         }
+    if writer_lease_factory is not None:
+        if writer_lease_state is None:
+            raise RuntimeError("managed ingestion writer lease state is unavailable")
+        writer_lease = writer_lease_factory()
+        writer_lease.__enter__()
+        writer_lease_state["manager"] = writer_lease
     conn.execute("BEGIN IMMEDIATE")
     current_binding_row = conn.execute(
         "SELECT id, root_path, repository_identity, checkout_identity FROM projects WHERE id = ?",
@@ -2330,10 +2467,13 @@ def ingest_repo(
     allow_root_rebind: bool = False,
     changed_paths=None,
     _root_rebind_capability=None,
+    _writer_lease_factory=None,
+    _initialize_schema: bool = True,
 ) -> dict:
     """Refresh a repository atomically so failed parses never leak a partial index."""
     if allow_root_rebind and _root_rebind_capability is not _ROOT_REBIND_CAPABILITY:
         raise ValueError("direct repository ingestion cannot rebind a project; use root-rebind with a backup path")
+    writer_lease_state = {}
     try:
         return _ingest_repo_impl(
             conn,
@@ -2344,10 +2484,17 @@ def ingest_repo(
             allow_root_rebind=allow_root_rebind,
             root_rebind_capability=_root_rebind_capability,
             changed_paths=changed_paths,
+            writer_lease_factory=_writer_lease_factory,
+            writer_lease_state=writer_lease_state,
+            initialize_schema=_initialize_schema,
         )
     except Exception:
         conn.rollback()
         raise
+    finally:
+        writer_lease = writer_lease_state.get("manager")
+        if writer_lease is not None:
+            writer_lease.__exit__(None, None, None)
 
 
 def _sha256_regular_file(path: Path) -> str:
@@ -2589,6 +2736,87 @@ def query_to_fts(query: str) -> str:
     return " OR ".join(selected[:8])
 
 
+def retrieval_relevance(query: str, project: str, results: dict) -> dict:
+    """Report whether retrieved evidence contains the task's distinctive anchors."""
+
+    raw_tokens = re.findall(r"[A-Za-z0-9][A-Za-z0-9_-]*", str(query)[:10_000])
+    meaningful = []
+    seen = set()
+    for token in raw_tokens:
+        lowered = token.casefold()
+        if lowered in QUERY_STOP_WORDS or lowered in GENERIC_TASK_TERMS or lowered in seen:
+            continue
+        seen.add(lowered)
+        meaningful.append(lowered)
+
+    evidence_parts = [str(project)]
+    for memory in results.get("memories", []):
+        evidence_parts.append(str(memory.get("text") or "")[:10_000])
+    for chunk in results.get("chunks", []):
+        evidence_parts.extend(
+            (str(chunk.get("path") or "")[:1_000], str(chunk.get("text") or "")[:10_000])
+        )
+    for claim in results.get("truth", []):
+        evidence_parts.extend(
+            (
+                str(claim.get("subject") or ""),
+                str(claim.get("predicate") or ""),
+                json.dumps(
+                    claim.get("object"), ensure_ascii=True, sort_keys=True, default=str
+                ),
+            )
+        )
+    evidence_tokens = {
+        token.casefold()
+        for token in re.findall(
+            r"[A-Za-z0-9][A-Za-z0-9_-]*", "\n".join(evidence_parts)
+        )
+    }
+    for token in tuple(evidence_tokens):
+        evidence_tokens.update(part for part in re.split(r"[-_]", token) if part)
+
+    matched = [term for term in meaningful if term in evidence_tokens]
+    distinctive = []
+    for token in raw_tokens:
+        lowered = token.casefold()
+        if (
+            lowered in QUERY_STOP_WORDS
+            or lowered in GENERIC_TASK_TERMS
+            or len(lowered) < 3
+        ):
+            continue
+        if (
+            token[0].isupper()
+            or "-" in token
+            or "_" in token
+            or any(character.isdigit() for character in token)
+        ) and lowered not in distinctive:
+            distinctive.append(lowered)
+    missing_distinctive = [
+        term for term in distinctive if term not in evidence_tokens
+    ]
+    evidence_count = sum(
+        len(results.get(name, [])) for name in ("memories", "chunks", "truth")
+    )
+
+    if not meaningful:
+        state, reason = "unassessed", "no_distinctive_query_terms"
+    elif evidence_count == 0:
+        state, reason = "insufficient", "no_retrieved_evidence"
+    elif missing_distinctive:
+        state, reason = "insufficient", "missing_distinctive_task_anchor"
+    elif len(meaningful) >= 4 and len(matched) / len(meaningful) < 0.25:
+        state, reason = "insufficient", "low_query_coverage"
+    else:
+        state, reason = "sufficient", "task_anchors_present"
+    return {
+        "state": state,
+        "reason": reason,
+        "matched_terms": matched,
+        "missing_distinctive_terms": missing_distinctive,
+    }
+
+
 _CONSEQUENTIAL_SOURCE_TERMS = {
     "active",
     "architecture",
@@ -2674,6 +2902,82 @@ def _source_authority_score(path: str, query: str) -> int:
     return score
 
 
+def _is_packaged_source_mirror(path: str) -> bool:
+    normalized = str(path or "").replace("\\", "/").casefold()
+    parts = {part for part in normalized.split("/") if part}
+    return bool(
+        parts
+        & {
+            "04_deployment",
+            "release-artifacts",
+            "release_artifacts",
+        }
+    )
+
+
+def _select_current_source_candidates(candidates, query: str) -> tuple[list, dict[str, int]]:
+    """Collapse byte-identical source copies onto one authoritative path."""
+
+    rows = list(candidates)
+    paths_by_hash: dict[str, set[str]] = {}
+    for row in rows:
+        source_hash = str(row["source_hash"] or "")
+        if source_hash:
+            paths_by_hash.setdefault(source_hash, set()).add(str(row["path"] or ""))
+
+    selected_path_by_hash: dict[str, str] = {}
+    duplicate_hashes = sum(
+        1 for paths in paths_by_hash.values() if len(paths) > 1
+    )
+    mirror_paths_rejected = 0
+    duplicate_paths_rejected = 0
+    for source_hash, paths in paths_by_hash.items():
+        if len(paths) < 2:
+            continue
+        selected_path = min(
+            paths,
+            key=lambda path: (
+                _is_packaged_source_mirror(path),
+                -_source_authority_score(path, query),
+                path.casefold(),
+            ),
+        )
+        selected_path_by_hash[source_hash] = selected_path
+        rejected_paths = paths - {selected_path}
+        duplicate_paths_rejected += len(rejected_paths)
+        mirror_paths_rejected += sum(
+            1 for path in rejected_paths if _is_packaged_source_mirror(path)
+        )
+
+    selected = []
+    seen_source_hashes: set[str] = set()
+    seen_chunk_hashes: set[tuple[str, str]] = set()
+    duplicate_chunks_rejected = 0
+    for row in rows:
+        source_hash = str(row["source_hash"] or "")
+        preferred_path = selected_path_by_hash.get(source_hash)
+        if preferred_path is not None and str(row["path"] or "") != preferred_path:
+            continue
+        if source_hash and source_hash in seen_source_hashes:
+            duplicate_chunks_rejected += 1
+            continue
+        chunk_hash = str(row["chunk_hash"] or "")
+        identity = (source_hash, chunk_hash)
+        if source_hash and chunk_hash and identity in seen_chunk_hashes:
+            continue
+        if source_hash:
+            seen_source_hashes.add(source_hash)
+        if source_hash and chunk_hash:
+            seen_chunk_hashes.add(identity)
+        selected.append(row)
+    return selected, {
+        "duplicate_source_hashes_collapsed": duplicate_hashes,
+        "duplicate_chunks_rejected": duplicate_chunks_rejected,
+        "duplicate_paths_rejected": duplicate_paths_rejected,
+        "mirror_paths_rejected": mirror_paths_rejected,
+    }
+
+
 def search(
     conn: sqlite3.Connection,
     query: str,
@@ -2693,9 +2997,14 @@ def search(
     if project:
         row = conn.execute("SELECT id FROM projects WHERE name = ?", (project,)).fetchone()
         if not row:
+            relevance = retrieval_relevance(
+                query,
+                project,
+                {"memories": [], "chunks": [], "truth": []},
+            )
             return {
                 "status": "ok", "query": query, "memories": [], "chunks": [], "truth": [],
-                "retrieval": {"mode": "fts", "provider": "none"},
+                "retrieval": {"mode": "fts", "provider": "none", "relevance": relevance},
             }
         project_id = int(row["id"])
     if project and _initialize:
@@ -2768,8 +3077,12 @@ def search(
 
     chunk_candidates = conn.execute(
         """
-        SELECT chunk_id, project_id, path, bm25(chunk_fts) AS rank
+        SELECT chunk_fts.chunk_id, chunk_fts.project_id, chunk_fts.path,
+               c.hash AS chunk_hash, s.hash AS source_hash,
+               bm25(chunk_fts) AS rank
         FROM chunk_fts
+        JOIN chunks c ON c.id = chunk_fts.chunk_id
+        JOIN sources s ON s.id = c.source_id
         WHERE chunk_fts MATCH ?
         ORDER BY rank
         LIMIT ?
@@ -2783,7 +3096,9 @@ def search(
     if consequential_source_query and project_id is not None:
         canonical_candidates = conn.execute(
             """
-            SELECT c.id AS chunk_id, s.project_id, s.title AS path, 1000000.0 AS rank
+            SELECT c.id AS chunk_id, s.project_id, s.title AS path,
+                   c.hash AS chunk_hash, s.hash AS source_hash,
+                   1000000.0 AS rank
             FROM sources s
             JOIN chunks c ON c.source_id = s.id AND c.ordinal = 0
             WHERE s.project_id = ?
@@ -2811,6 +3126,9 @@ def search(
                 str(row["path"] or ""),
             ),
         )
+    project_chunks, current_source_selection = _select_current_source_candidates(
+        project_chunks, query
+    )
     selected_chunks = project_chunks[:limit]
     chunks = []
     if selected_chunks:
@@ -2838,6 +3156,7 @@ def search(
                 )
                 item["path"] = candidate["path"]
                 item["rank"] = candidate["rank"]
+                item["chunk_hash"] = candidate["chunk_hash"]
                 item["source_authority_score"] = _source_authority_score(
                     str(candidate["path"] or ""), query
                 )
@@ -2846,13 +3165,20 @@ def search(
         "mode": "fts",
         "provider": "none",
         "canonical_source_reranking": consequential_source_query,
+        "current_source_selection": current_source_selection,
     }
     if use_hybrid and project_id is not None:
-        provider = create_provider(provider_name, str(settings["embedding_model"]))
+        query_only = bool(conn.execute("PRAGMA query_only").fetchone()[0])
+        provider = create_provider(
+            provider_name,
+            str(settings["embedding_model"]),
+            local_files_only=query_only,
+        )
         query_vector = provider.embed([query])[0]
         semantic_rows = conn.execute(
             """
-            SELECT ce.chunk_id, ce.vector_json, c.text, s.hash AS source_hash,
+            SELECT ce.chunk_id, ce.vector_json, c.text, c.hash AS chunk_hash,
+                   s.hash AS source_hash,
                    s.title AS path, s.metadata_json AS source_metadata_json,
                    p.name AS project
             FROM chunk_embeddings ce
@@ -2877,7 +3203,8 @@ def search(
             if chunk_id not in merged:
                 merged[chunk_id] = {
                     "id": chunk_id, "project": row["project"], "text": str(row["text"])[:500],
-                    "source_hash": row["source_hash"], "path": row["path"], "rank": None,
+                    "source_hash": row["source_hash"], "chunk_hash": row["chunk_hash"],
+                    "path": row["path"], "rank": None,
                     "privacy_class": _graph_metadata_privacy_class(
                         row["source_metadata_json"]
                     ),
@@ -2889,11 +3216,20 @@ def search(
             item["lexical_score"] = round(lexical_score, 6)
             item["semantic_score"] = round(semantic_score, 6)
             item["hybrid_score"] = round((1.0 - semantic_weight) * lexical_score + semantic_weight * semantic_score, 6)
-        chunks = sorted(merged.values(), key=lambda item: (-item["hybrid_score"], str(item["path"])))[:limit]
+        hybrid_candidates, current_source_selection = _select_current_source_candidates(
+            merged.values(), query
+        )
+        chunks = sorted(
+            hybrid_candidates,
+            key=lambda item: (-item["hybrid_score"], str(item["path"])),
+        )[:limit]
         retrieval = {
             "mode": "hybrid", "provider": provider.name, "model": provider.model,
             "semantic_weight": semantic_weight, "candidates": len(merged),
+            "current_source_selection": current_source_selection,
         }
+    for item in chunks:
+        item.pop("chunk_hash", None)
     truth = []
     truth_schema_available = conn.execute(
         "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'truth_claim_versions'"
@@ -2915,6 +3251,11 @@ def search(
             (project_id, query, json.dumps(selected), now_iso()),
         )
         conn.commit()
+    retrieval["relevance"] = retrieval_relevance(
+        query,
+        project or "",
+        {"memories": memories, "chunks": chunks, "truth": truth},
+    )
     return {
         "status": "ok", "query": query, "memories": memories,
         "chunks": chunks, "truth": truth, "retrieval": retrieval,

--- a/rta_brain/embeddings.py
+++ b/rta_brain/embeddings.py
@@ -45,7 +45,12 @@ class SentenceTransformerEmbeddingProvider:
 
     name = "sentence-transformers"
 
-    def __init__(self, model: str = "all-MiniLM-L6-v2") -> None:
+    def __init__(
+        self,
+        model: str = "all-MiniLM-L6-v2",
+        *,
+        local_files_only: bool = False,
+    ) -> None:
         try:
             from sentence_transformers import SentenceTransformer
         except ImportError as exc:
@@ -53,21 +58,29 @@ class SentenceTransformerEmbeddingProvider:
                 "sentence-transformers is not installed; use the hash provider or install the optional package"
             ) from exc
         self.model = model
-        self._model = SentenceTransformer(model)
+        self._model = SentenceTransformer(model, local_files_only=local_files_only)
 
     def embed(self, texts: list[str]) -> list[list[float]]:
         vectors = self._model.encode(texts, normalize_embeddings=True)
         return [[float(value) for value in vector] for vector in vectors]
 
 
-def create_provider(name: str, model: str | None = None) -> EmbeddingProvider | None:
+def create_provider(
+    name: str,
+    model: str | None = None,
+    *,
+    local_files_only: bool = False,
+) -> EmbeddingProvider | None:
     normalized = (name or "none").strip().lower()
     if normalized == "none":
         return None
     if normalized == "hash":
         return HashEmbeddingProvider()
     if normalized == "sentence-transformers":
-        return SentenceTransformerEmbeddingProvider(model or "all-MiniLM-L6-v2")
+        return SentenceTransformerEmbeddingProvider(
+            model or "all-MiniLM-L6-v2",
+            local_files_only=local_files_only,
+        )
     raise ValueError(f"unknown embedding provider: {name}")
 
 

--- a/rta_brain/mcp_server.py
+++ b/rta_brain/mcp_server.py
@@ -52,6 +52,7 @@ from .continuity_daemon import (
 )
 from .db import (
     connect,
+    connect_readonly,
     doctor,
     graph,
     graph_query,
@@ -1997,7 +1998,8 @@ class RtaBrainMcpServer:
             )
         return root
 
-    def _open_project(self, project: str | None):
+    def _open_project(self, project: str | None, *, readonly: bool = False):
+        connection_factory = connect_readonly if readonly else connect
         if self.db_path is not None:
             if not self.default_project:
                 raise ValueError("single-database MCP mode requires a default project")
@@ -2006,7 +2008,7 @@ class RtaBrainMcpServer:
                 raise ValueError(
                     f"MCP server is bound to project '{self.default_project}'; client project overrides are rejected"
                 )
-            conn = connect(self.db_path)
+            conn = connection_factory(self.db_path)
             binding = project_binding_status(conn, self.default_project, self.expected_root)
             row = conn.execute(
                 "SELECT root_path, repository_identity, checkout_identity FROM projects WHERE name = ?",
@@ -2032,7 +2034,7 @@ class RtaBrainMcpServer:
             if candidate.is_symlink() or not candidate.is_file() or candidate.stat().st_nlink > 1:
                 continue
             before = candidate.stat()
-            conn = connect(candidate)
+            conn = connection_factory(candidate)
             after = candidate.stat()
             if before.st_dev != after.st_dev or before.st_ino != after.st_ino:
                 conn.close()
@@ -2061,7 +2063,11 @@ class RtaBrainMcpServer:
             if self.db_path is not None else nullcontext()
         )
         with guard:
-            conn, db_path, project = self._open_project(args.get("project") or self.default_project)
+            lock_free_read = name in {"brain_search", "brain_context_pack"}
+            conn, db_path, project = self._open_project(
+                args.get("project") or self.default_project,
+                readonly=lock_free_read,
+            )
             try:
                 result = self._call_tool_with_connection(
                     conn, name, args, db_path=db_path, resolved_project=project
@@ -2171,6 +2177,7 @@ class RtaBrainMcpServer:
                 str(args["query"]),
                 project=project,
                 limit=int(args.get("limit", 8)),
+                record_recall=False,
             )
             payload = _filter_search_payload(
                 conn,

--- a/rta_brain/runtime_control.py
+++ b/rta_brain/runtime_control.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import errno
+import hashlib
 import json
 import os
 import shutil
@@ -11,11 +13,229 @@ import subprocess
 import sys
 import time
 import uuid
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable, Iterator
+from contextlib import contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
 
 from .platform_paths import canonicalize_system_root_alias
+
+
+@contextmanager
+def database_writer_lease(
+    db_path: Path,
+    *,
+    timeout_seconds: float | None = None,
+    on_wait: Callable[[float], None] | None = None,
+    stop_requested: Callable[[], bool] | None = None,
+) -> Iterator[dict[str, float | str]]:
+    """Serialize background writers for one brain using a crash-safe OS lock."""
+
+    database = canonicalize_system_root_alias(
+        Path(os.path.abspath(Path(db_path).expanduser()))
+    )
+    control_dir = database.parent / ".rta-smriti-daemons"
+    prepare_control_dir(control_dir, label="database writer")
+    key = hashlib.sha256(str(database).casefold().encode("utf-8")).hexdigest()[:16]
+    lock_path = control_dir / f"{database.stem}-{key}.writer.lock"
+    if lock_path.exists() and not is_safe_regular_file(lock_path):
+        raise ValueError(f"database writer lock is linked or unsafe: {lock_path}")
+    flags = os.O_CREAT | os.O_RDWR | int(getattr(os, "O_CLOEXEC", 0))
+    flags |= int(getattr(os, "O_NOFOLLOW", 0))
+    descriptor = os.open(lock_path, flags, 0o600)
+    ticket_path: Path | None = None
+    started = time.monotonic()
+    deadline = (
+        None
+        if timeout_seconds is None
+        else started + max(0.0, float(timeout_seconds))
+    )
+    last_notice = -1.0
+    try:
+        details = os.fstat(descriptor)
+        if not stat.S_ISREG(details.st_mode) or details.st_nlink != 1:
+            raise ValueError(f"database writer lock is linked or unsafe: {lock_path}")
+        if details.st_size == 0:
+            os.write(descriptor, b"\0")
+            os.fsync(descriptor)
+        _ensure_private_windows_path(lock_path, label="database writer lock")
+        if os.name != "nt":
+            os.fchmod(descriptor, 0o600)
+        ticket_path = _create_writer_ticket(control_dir, database.stem, key)
+        while True:
+            now = time.monotonic()
+            waited = now - started
+            if stop_requested is not None and stop_requested():
+                raise InterruptedError("database writer lease was cancelled")
+            if deadline is not None and now >= deadline:
+                raise TimeoutError(
+                    f"database writer lease timed out after {waited:.1f} seconds"
+                )
+            queue = _active_writer_tickets(control_dir, database.stem, key)
+            is_head = bool(queue) and queue[0] == ticket_path
+            if is_head and _try_lock_descriptor(descriptor):
+                now = time.monotonic()
+                waited = now - started
+                if stop_requested is not None and stop_requested():
+                    raise InterruptedError("database writer lease was cancelled")
+                if deadline is not None and now >= deadline:
+                    raise TimeoutError(
+                        f"database writer lease timed out after {waited:.1f} seconds"
+                    )
+                _remove_writer_ticket(ticket_path)
+                ticket_path = None
+                break
+            if on_wait is not None and (last_notice < 0 or waited - last_notice >= 1.0):
+                on_wait(waited)
+                last_notice = waited
+            time.sleep(0.025)
+        waited = time.monotonic() - started
+        yield {"lock_path": str(lock_path), "wait_seconds": waited}
+    finally:
+        if ticket_path is not None:
+            _remove_writer_ticket(ticket_path)
+        try:
+            _unlock_descriptor(descriptor)
+        except OSError:
+            pass
+        os.close(descriptor)
+
+
+def _create_writer_ticket(control_dir: Path, database_stem: str, key: str) -> Path:
+    pid = os.getpid()
+    identity = process_identity(pid)
+    if identity is None:
+        raise RuntimeError("cannot establish process identity for database writer queue")
+    prefix = f"{database_stem}-{key}.writer"
+    payload = json.dumps(
+        {"pid": pid, "process_identity": identity},
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    for _ in range(8):
+        sequence = time.monotonic_ns()
+        token = uuid.uuid4().hex
+        ticket_path = control_dir / f"{prefix}.{sequence:020d}-{token}.ticket"
+        temporary = control_dir / f".{prefix}.{sequence:020d}-{token}.pending"
+        flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY | int(getattr(os, "O_CLOEXEC", 0))
+        flags |= int(getattr(os, "O_NOFOLLOW", 0))
+        try:
+            ticket_descriptor = os.open(temporary, flags, 0o600)
+        except FileExistsError:
+            continue
+        try:
+            details = os.fstat(ticket_descriptor)
+            if not stat.S_ISREG(details.st_mode) or details.st_nlink != 1:
+                raise ValueError(f"database writer ticket is linked or unsafe: {temporary}")
+            os.write(ticket_descriptor, payload)
+            os.fsync(ticket_descriptor)
+            if os.name != "nt":
+                os.fchmod(ticket_descriptor, 0o600)
+        finally:
+            os.close(ticket_descriptor)
+        try:
+            _ensure_private_windows_path(temporary, label="database writer ticket")
+            os.replace(temporary, ticket_path)
+            _ensure_private_windows_path(ticket_path, label="database writer ticket")
+            return ticket_path
+        finally:
+            temporary.unlink(missing_ok=True)
+    raise RuntimeError("cannot allocate a unique database writer queue ticket")
+
+
+def _active_writer_tickets(
+    control_dir: Path, database_stem: str, key: str
+) -> list[Path]:
+    prefix = f"{database_stem}-{key}.writer."
+    active: list[Path] = []
+    for ticket_path in control_dir.iterdir():
+        if not ticket_path.name.startswith(prefix) or not ticket_path.name.endswith(".ticket"):
+            continue
+        try:
+            payload = _read_writer_ticket(ticket_path)
+            pid = int(payload["pid"])
+            expected_identity = str(payload["process_identity"])
+        except FileNotFoundError:
+            continue
+        except (KeyError, TypeError, ValueError, UnicodeError, json.JSONDecodeError) as exc:
+            raise ValueError(f"database writer ticket is invalid: {ticket_path}") from exc
+        if process_identity(pid) != expected_identity:
+            _remove_writer_ticket(ticket_path)
+            continue
+        active.append(ticket_path)
+    return sorted(active, key=lambda path: path.name)
+
+
+def _read_writer_ticket(ticket_path: Path) -> dict:
+    before = ticket_path.lstat()
+    if (
+        not stat.S_ISREG(before.st_mode)
+        or ticket_path.is_symlink()
+        or _is_reparse_point(ticket_path)
+        or int(getattr(before, "st_nlink", 1)) != 1
+    ):
+        raise ValueError(f"database writer ticket is linked or unsafe: {ticket_path}")
+    if before.st_size > 4_096:
+        raise ValueError(f"database writer ticket is oversized: {ticket_path}")
+    flags = os.O_RDONLY | int(getattr(os, "O_CLOEXEC", 0))
+    flags |= int(getattr(os, "O_NOFOLLOW", 0))
+    descriptor = os.open(ticket_path, flags)
+    try:
+        opened = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or int(getattr(opened, "st_nlink", 1)) != 1
+            or not os.path.samestat(before, opened)
+        ):
+            raise ValueError(f"database writer ticket changed while opening: {ticket_path}")
+        payload = os.read(descriptor, 4_097)
+        if len(payload) > 4_096:
+            raise ValueError(f"database writer ticket is oversized: {ticket_path}")
+        after = ticket_path.lstat()
+        if not os.path.samestat(opened, after) or int(after.st_size) != len(payload):
+            raise ValueError(f"database writer ticket changed while reading: {ticket_path}")
+        return json.loads(payload.decode("utf-8"))
+    finally:
+        os.close(descriptor)
+
+
+def _remove_writer_ticket(ticket_path: Path) -> None:
+    try:
+        if ticket_path.exists() and not is_safe_regular_file(ticket_path):
+            raise ValueError(f"database writer ticket is linked or unsafe: {ticket_path}")
+        ticket_path.unlink(missing_ok=True)
+    except FileNotFoundError:
+        pass
+
+
+def _try_lock_descriptor(descriptor: int) -> bool:
+    try:
+        if os.name == "nt":
+            import msvcrt
+
+            os.lseek(descriptor, 0, os.SEEK_SET)
+            msvcrt.locking(descriptor, msvcrt.LK_NBLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return True
+    except OSError as exc:
+        if exc.errno in {errno.EACCES, errno.EAGAIN, errno.EDEADLK}:
+            return False
+        raise
+
+
+def _unlock_descriptor(descriptor: int) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        msvcrt.locking(descriptor, msvcrt.LK_UNLCK, 1)
+    else:
+        import fcntl
+
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
 
 
 def now_iso() -> str:

--- a/rta_brain/watch_daemon.py
+++ b/rta_brain/watch_daemon.py
@@ -11,12 +11,14 @@ import sys
 import threading
 import time
 import uuid
+from contextlib import contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
 
-from .db import connect, ingest_repo
+from .db import bounded_wal_checkpoint, connect, ingest_repo
 from .runtime_control import (
     clear_control_files,
+    database_writer_lease,
     detach_current_worker_session,
     detached_worker_bootstrap,
     is_safe_regular_file,
@@ -422,6 +424,17 @@ def run_watcher_worker(
         "last_error": None,
         **counters,
     }
+    state_lock = threading.Lock()
+    heartbeat_stop = threading.Event()
+
+    def persist_state() -> None:
+        with state_lock:
+            state["heartbeat_at"] = _now_iso()
+            _write_json(state_file, dict(state))
+
+    def heartbeat_loop() -> None:
+        while not heartbeat_stop.wait(5.0):
+            persist_state()
 
     def request_stop(_signum=None, _frame=None) -> None:
         stop_event.set()
@@ -465,7 +478,11 @@ def run_watcher_worker(
         except (ImportError, OSError, RuntimeError):
             observer = None
         state["state"] = "running"
-        _write_json(state_file, state)
+        persist_state()
+        heartbeat_thread = threading.Thread(
+            target=heartbeat_loop, name="rta-watcher-heartbeat", daemon=True
+        )
+        heartbeat_thread.start()
         should_index = True
         while not stop_event.is_set() and not _stop_requested(stop_file):
             if should_index:
@@ -477,12 +494,40 @@ def run_watcher_worker(
                 if backend == "polling" and time.monotonic() - last_deep_verify >= deep_verify_interval:
                     force_cycle = True
                 try:
-                    conn = connect(db_path)
+                    def report_writer_wait(waited: float) -> None:
+                        state["writer_state"] = "waiting"
+                        state["writer_wait_seconds"] = round(waited, 3)
+                        persist_state()
+
+                    @contextmanager
+                    def writer_turn():
+                        with database_writer_lease(
+                            db_path, on_wait=report_writer_wait
+                        ) as writer_receipt:
+                            state["writer_state"] = "active"
+                            state["writer_wait_seconds"] = round(
+                                float(writer_receipt["wait_seconds"]), 3
+                            )
+                            persist_state()
+                            try:
+                                yield writer_receipt
+                            finally:
+                                state["writer_state"] = "idle"
+                                persist_state()
+
+                    with writer_turn():
+                        conn = connect(db_path)
                     try:
                         result = ingest_repo(
                             conn, root, project=project, force=force_cycle,
                             changed_paths=cycle_paths,
+                            _writer_lease_factory=writer_turn,
+                            _initialize_schema=False,
                         )
+                        with writer_turn():
+                            state["wal_checkpoint"] = bounded_wal_checkpoint(
+                                conn, db_path
+                            )
                     finally:
                         conn.close()
                     if force_cycle:
@@ -506,10 +551,10 @@ def run_watcher_worker(
                                 pending_changes["force_full"] = True
                         pending_changes["force_full"] = pending_changes["force_full"] or force_cycle
                     counters["errors"] += 1
+                    state["writer_state"] = "error"
                     state["last_error"] = f"{exc.__class__.__name__}: {exc}"
                 state.update(counters)
-            state["heartbeat_at"] = _now_iso()
-            _write_json(state_file, state)
+            persist_state()
             if backend == "watchdog":
                 changed = change_event.wait(timeout=max(0.1, min(float(interval_seconds), 5.0)))
                 if changed:
@@ -520,24 +565,25 @@ def run_watcher_worker(
                 stop_event.wait(timeout=effective_poll_interval)
                 should_index = True
         state["state"] = "stopping"
-        state["heartbeat_at"] = _now_iso()
-        _write_json(state_file, state)
+        persist_state()
         return 0
     except Exception as exc:
         state["state"] = "error"
         state["last_error"] = f"{exc.__class__.__name__}: {exc}"
-        state["heartbeat_at"] = _now_iso()
-        _write_json(state_file, state)
+        persist_state()
         return 1
     finally:
+        heartbeat_stop.set()
+        thread = locals().get("heartbeat_thread")
+        if thread is not None:
+            thread.join(timeout=10)
         if observer is not None:
             observer.stop()
             observer.join(timeout=5)
         if state.get("state") != "error":
             state["state"] = "stopped"
             state["stopped_at"] = _now_iso()
-            state["heartbeat_at"] = _now_iso()
-            _write_json(state_file, state)
+            persist_state()
         if _is_safe_regular_file(stop_file):
             stop_file.unlink(missing_ok=True)
         try:

--- a/scripts/installed_distribution_smoke.py
+++ b/scripts/installed_distribution_smoke.py
@@ -195,6 +195,14 @@ def wait_for_url(process: subprocess.Popen[str], timeout: float = 15) -> str:
     raise TimeoutError("dashboard did not emit its capability URL")
 
 
+def create_private_directory(path: Path) -> None:
+    path.mkdir(mode=0o700)
+    if os.name != "nt":
+        path.chmod(0o700)
+        if path.stat().st_mode & 0o077:
+            raise RuntimeError(f"smoke-test private directory permissions are unsafe: {path}")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Smoke-test an installed Rta-Smriti distribution")
     parser.add_argument("--cli", required=True, type=Path)
@@ -207,6 +215,7 @@ def main() -> int:
         root = Path(tmp)
         project = root / "sample-project"
         brains = root / "brains"
+        create_private_directory(brains)
         project.mkdir()
         (project / "app.py").write_text("def hello():\n    return 'world'\n", encoding="utf-8")
 

--- a/tests/test_blueprint_hardening.py
+++ b/tests/test_blueprint_hardening.py
@@ -1,5 +1,7 @@
 import asyncio
 import concurrent.futures
+import contextlib
+import io
 import json
 import shutil
 import sqlite3
@@ -11,6 +13,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from rta_brain import db, project, repository
+from rta_brain.cli import main as cli_main
 from rta_brain.console import read_file_preview
 from rta_brain.context import build_context_pack, estimate_tokens
 from rta_brain.mcp_server import RtaBrainMcpServer
@@ -18,6 +21,128 @@ from rta_brain.parsers import ParserRegistry
 
 
 class RtaBrainBlueprintHardeningTests(unittest.TestCase):
+    def test_read_only_connection_never_creates_or_mutates_a_brain(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            database = Path(tmp) / "brain.sqlite"
+            with self.assertRaisesRegex(ValueError, "existing brain database"):
+                db.connect_readonly(database)
+            self.assertFalse(database.exists())
+
+            writer = db.connect(database)
+            try:
+                db.init_project(writer, "demo", str(Path(tmp)))
+            finally:
+                writer.close()
+
+            reader = db.connect_readonly(database)
+            try:
+                self.assertEqual(reader.execute("PRAGMA query_only").fetchone()[0], 1)
+                self.assertEqual(reader.execute("PRAGMA busy_timeout").fetchone()[0], 5000)
+                with self.assertRaisesRegex(sqlite3.OperationalError, "readonly"):
+                    reader.execute(
+                        "UPDATE projects SET created_at = created_at WHERE name = 'demo'"
+                    )
+            finally:
+                reader.close()
+
+    def test_cli_context_pack_uses_the_read_only_connection_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            root.mkdir()
+            (root / "README.md").write_text("# Demo\n\nPlanning evidence.\n", encoding="utf-8")
+            database = Path(tmp) / "brain.sqlite"
+            writer = db.connect(database)
+            try:
+                db.ingest_repo(writer, root, project="demo")
+            finally:
+                writer.close()
+
+            output = io.StringIO()
+            with (
+                patch("rta_brain.cli.connect", side_effect=AssertionError("writer connection used")),
+                contextlib.redirect_stdout(output),
+            ):
+                result = cli_main(
+                    [
+                        "context-pack",
+                        "Demo planning evidence",
+                        "--db",
+                        str(database),
+                        "--project",
+                        "demo",
+                        "--json",
+                    ]
+                )
+            self.assertEqual(result, 0)
+            self.assertIn("Rta-Smriti Context Pack", output.getvalue())
+
+    def test_cli_search_accepts_an_explicit_read_only_json_contract(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            root.mkdir()
+            (root / "README.md").write_text(
+                "# Demo\n\nVerified mission evidence.\n",
+                encoding="utf-8",
+            )
+            database = Path(tmp) / "brain.sqlite"
+            writer = db.connect(database)
+            try:
+                db.ingest_repo(writer, root, project="demo")
+            finally:
+                writer.close()
+
+            output = io.StringIO()
+            with (
+                patch(
+                    "rta_brain.cli.connect",
+                    side_effect=AssertionError("writer connection used"),
+                ),
+                contextlib.redirect_stdout(output),
+            ):
+                result = cli_main(
+                    [
+                        "search",
+                        "verified mission evidence",
+                        "--db",
+                        str(database),
+                        "--project",
+                        "demo",
+                        "--limit",
+                        "1",
+                        "--json",
+                        "--read-only",
+                    ]
+                )
+
+            self.assertEqual(result, 0)
+            payload = json.loads(output.getvalue())
+            self.assertEqual(payload["access"]["mode"], "read_only")
+            self.assertFalse(payload["access"]["writes_performed"])
+            self.assertEqual(payload["chunks"][0]["path"], "README.md")
+
+    def test_mcp_context_pack_uses_the_read_only_connection_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            root.mkdir()
+            (root / "README.md").write_text("# Demo\n\nPlanning evidence.\n", encoding="utf-8")
+            database = Path(tmp) / "brain.sqlite"
+            writer = db.connect(database)
+            try:
+                db.ingest_repo(writer, root, project="demo")
+            finally:
+                writer.close()
+            server = RtaBrainMcpServer(database, "demo", expected_root=root)
+
+            with patch(
+                "rta_brain.mcp_server.connect",
+                side_effect=AssertionError("writer connection used"),
+            ):
+                result = server.call_tool(
+                    "brain_context_pack",
+                    {"task": "Demo planning evidence", "project": "demo"},
+                )
+            self.assertFalse(result.get("isError", False))
+
     def test_connections_use_wal_normal_sync_and_bounded_busy_wait(self):
         with tempfile.TemporaryDirectory() as tmp:
             conn = db.connect(Path(tmp) / "brain.sqlite")
@@ -317,6 +442,71 @@ class RtaBrainBlueprintHardeningTests(unittest.TestCase):
                         self.assertEqual(result["chunks"][0]["path"], expected)
             finally:
                 conn.close()
+
+    def test_search_prefers_current_source_and_collapses_packaged_mirrors(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            current = root / "02_Code" / "core" / "golden_mission.py"
+            mirrors = (
+                root / "04_Deployment" / "wheel" / "golden_mission.py",
+                root / "04_Deployment" / "native" / "golden_mission.py",
+                root / "04_Deployment" / "portable" / "golden_mission.py",
+            )
+            body = (
+                "def compile_golden_mission():\n"
+                "    return 'current source selection for golden mission trace'\n"
+            )
+            current.parent.mkdir(parents=True)
+            current.write_text(body, encoding="utf-8")
+            for mirror in mirrors:
+                mirror.parent.mkdir(parents=True)
+                mirror.write_text(body, encoding="utf-8")
+
+            conn = db.connect(Path(tmp) / "brain.sqlite")
+            try:
+                db.ingest_repo(conn, root, project="demo")
+                result = db.search(
+                    conn,
+                    "golden mission trace current selection",
+                    project="demo",
+                    limit=4,
+                )
+                self.assertEqual(
+                    [item["path"] for item in result["chunks"]],
+                    ["02_Code/core/golden_mission.py"],
+                )
+                self.assertNotIn("chunk_hash", result["chunks"][0])
+                self.assertEqual(
+                    result["retrieval"]["current_source_selection"]["mirror_paths_rejected"],
+                    3,
+                )
+                self.assertEqual(
+                    result["retrieval"]["current_source_selection"]["duplicate_source_hashes_collapsed"],
+                    1,
+                )
+            finally:
+                conn.close()
+
+    def test_current_source_selection_does_not_count_multiple_chunks_as_duplicate_sources(self):
+        rows = [
+            {
+                "source_hash": "source-one",
+                "chunk_hash": "chunk-one",
+                "path": "02_Code/core/current.py",
+            },
+            {
+                "source_hash": "source-one",
+                "chunk_hash": "chunk-two",
+                "path": "02_Code/core/current.py",
+            },
+        ]
+
+        selected, report = db._select_current_source_candidates(rows, "current source")
+
+        self.assertEqual(len(selected), 1)
+        self.assertEqual(report["duplicate_source_hashes_collapsed"], 0)
+        self.assertEqual(report["duplicate_paths_rejected"], 0)
+        self.assertEqual(report["duplicate_chunks_rejected"], 1)
 
     def test_canonical_control_files_have_a_narrow_oversize_ingestion_allowance(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_brain_cli.py
+++ b/tests/test_brain_cli.py
@@ -1,3 +1,4 @@
+import io
 import json
 import subprocess
 import sys
@@ -23,6 +24,20 @@ def run_cli(*args, cwd=None):
 
 
 class RtaBrainCliTests(unittest.TestCase):
+    def test_emit_reconfigures_a_windows_console_stream_for_utf8(self):
+        from rta_brain import cli
+
+        buffer = io.BytesIO()
+        stream = io.TextIOWrapper(buffer, encoding="cp1252")
+        with patch.object(cli.sys, "stdout", stream):
+            cli._configure_utf8_output()
+            cli.emit("\ufeffCurrent RTA-Net evidence", as_json=False)
+            stream.flush()
+        self.assertEqual(
+            buffer.getvalue().decode("utf-8").splitlines(),
+            ["\ufeffCurrent RTA-Net evidence"],
+        )
+
     def test_repo_ingestion_enforces_aggregate_budgets(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_build_installed_smoke_security.py
+++ b/tests/test_build_installed_smoke_security.py
@@ -8,9 +8,20 @@ import sys
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
 from scripts import build_installed_smoke
+from scripts import installed_distribution_smoke
 
 
 class InstalledSmokeSecurityTests(unittest.TestCase):
+    def test_private_smoke_directory_rejects_group_or_world_access(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "brains"
+
+            installed_distribution_smoke.create_private_directory(target)
+
+            self.assertTrue(target.is_dir())
+            if sys.platform != "win32":
+                self.assertEqual(target.stat().st_mode & 0o077, 0)
+
     def test_extraction_rejects_windows_escape_paths(self):
         unc_member = "\\" * 2 + r"server\share\escape.txt"
         for member in (r"..\..\escape.txt", r"C:\escape.txt", unc_member):

--- a/tests/test_continuity_daemon.py
+++ b/tests/test_continuity_daemon.py
@@ -3,11 +3,12 @@ import os
 import tempfile
 import time
 import unittest
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
 
-from rta_brain import db
 from rta_brain import continuity_daemon as continuity_module
+from rta_brain import db
 from rta_brain.continuity_daemon import (
     capture_cycle,
     continuity_binding_diagnostics,
@@ -604,6 +605,142 @@ class ContinuityDaemonTests(unittest.TestCase):
                 ).fetchone()
                 self.assertEqual(event["source"], "ollama-local")
                 self.assertEqual(event["verification_status"], "unverified")
+            finally:
+                conn.close()
+
+    def test_managed_compaction_runs_model_before_requesting_writer_lease(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp); project = base / "project"; sessions = base / "sessions"
+            project.mkdir(); sessions.mkdir(); transcript = sessions / "thread.jsonl"
+            rows = [
+                {"type": "session_meta", "payload": {"id": "thread-deferred", "cwd": str(project)}},
+                {"type": "response_item", "payload": {"type": "message", "role": "user", "content": "Preserve writer fairness"}},
+                {"type": "event_msg", "payload": {"type": "task_complete", "message": "Done"}},
+            ]
+            transcript.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+            database = base / "brain.sqlite"
+            conn = db.connect(database)
+            try:
+                db.init_project(conn, "demo", str(project))
+                db.update_project_settings(conn, "demo", {"compaction_provider": "ollama"})
+                prepared = capture_cycle(
+                    conn,
+                    sessions,
+                    project,
+                    "demo",
+                    inactivity_seconds=3600,
+                    defer_model_compaction=True,
+                )
+            finally:
+                conn.close()
+
+            self.assertEqual(prepared["checkpoints_created"], 0)
+            self.assertEqual(len(prepared["_deferred_checkpoints"]), 1)
+            writer_active = False
+            observed = []
+
+            def compacted(*_args, **_kwargs):
+                observed.append("model")
+                self.assertFalse(writer_active)
+                return {
+                    "status": "ok", "provider": "ollama", "model": "qwen3:0.6b",
+                    "summary": "Objective: preserve writer fairness", "verification_status": "unverified",
+                    "input_events": 3, "redactions": 0,
+                }
+
+            @contextmanager
+            def observed_lease(*_args, **_kwargs):
+                nonlocal writer_active
+                observed.append("lease")
+                writer_active = True
+                try:
+                    yield {"wait_seconds": 0.0}
+                finally:
+                    writer_active = False
+
+            with (
+                patch.object(continuity_module, "compact_session_events", side_effect=compacted),
+                patch.object(continuity_module, "database_writer_lease", side_effect=observed_lease),
+            ):
+                completed = continuity_module._complete_deferred_checkpoint(
+                    database,
+                    "demo",
+                    prepared["_deferred_checkpoints"][0],
+                )
+
+            self.assertEqual(observed, ["model", "lease"])
+            self.assertTrue(completed["created"])
+            with (
+                patch.object(continuity_module, "compact_session_events", side_effect=compacted),
+                patch.object(continuity_module, "database_writer_lease", side_effect=observed_lease),
+            ):
+                duplicate = continuity_module._complete_deferred_checkpoint(
+                    database,
+                    "demo",
+                    prepared["_deferred_checkpoints"][0],
+                )
+            self.assertFalse(duplicate["created"])
+            conn = db.connect(database)
+            try:
+                checkpoint = db.latest_checkpoint(conn, "demo")
+                self.assertIn("Local-model summary (unverified)", checkpoint["remaining_gaps"])
+                event = conn.execute(
+                    "SELECT source, verification_status FROM session_events "
+                    "WHERE event_type = 'continuity_compaction'"
+                ).fetchone()
+                self.assertEqual(event["source"], "ollama-local")
+                self.assertEqual(event["verification_status"], "unverified")
+                self.assertEqual(
+                    conn.execute("SELECT COUNT(*) FROM checkpoints").fetchone()[0],
+                    1,
+                )
+            finally:
+                conn.close()
+
+    def test_deferred_compaction_failure_preserves_deterministic_checkpoint(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp); project = base / "project"; sessions = base / "sessions"
+            project.mkdir(); sessions.mkdir(); transcript = sessions / "thread.jsonl"
+            rows = [
+                {"type": "session_meta", "payload": {"id": "thread-failure", "cwd": str(project)}},
+                {"type": "response_item", "payload": {"type": "message", "role": "user", "content": "Keep deterministic state"}},
+                {"type": "event_msg", "payload": {"type": "task_complete", "message": "Done"}},
+            ]
+            transcript.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+            database = base / "brain.sqlite"
+            conn = db.connect(database)
+            try:
+                db.init_project(conn, "demo", str(project))
+                db.update_project_settings(conn, "demo", {"compaction_provider": "ollama"})
+                prepared = capture_cycle(
+                    conn, sessions, project, "demo", inactivity_seconds=3600,
+                    defer_model_compaction=True,
+                )
+            finally:
+                conn.close()
+
+            with patch.object(
+                continuity_module,
+                "compact_session_events",
+                side_effect=TimeoutError("local model timed out"),
+            ):
+                completed = continuity_module._complete_deferred_checkpoint(
+                    database,
+                    "demo",
+                    prepared["_deferred_checkpoints"][0],
+                )
+
+            self.assertTrue(completed["created"])
+            conn = db.connect(database)
+            try:
+                checkpoint = db.latest_checkpoint(conn, "demo")
+                self.assertIn("compaction was unavailable", checkpoint["remaining_gaps"])
+                self.assertEqual(
+                    conn.execute(
+                        "SELECT COUNT(*) FROM session_events WHERE event_type = 'continuity_compaction'"
+                    ).fetchone()[0],
+                    0,
+                )
             finally:
                 conn.close()
 

--- a/tests/test_database_concurrency.py
+++ b/tests/test_database_concurrency.py
@@ -1,0 +1,403 @@
+import ast
+import os
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+from rta_brain import db
+from rta_brain import runtime_control
+from rta_brain.runtime_control import database_writer_lease
+
+
+class DatabaseConcurrencyTests(unittest.TestCase):
+    def test_all_background_writers_use_serialized_maintenance(self):
+        root = Path(__file__).resolve().parents[1] / "rta_brain"
+        for name in ("watch_daemon.py", "capture_daemon.py", "continuity_daemon.py"):
+            tree = ast.parse((root / name).read_text(encoding="utf-8"))
+            calls = {
+                node.func.id
+                for node in ast.walk(tree)
+                if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+            }
+            self.assertIn("database_writer_lease", calls, name)
+            self.assertIn("bounded_wal_checkpoint", calls, name)
+
+    def test_managed_writer_waits_are_bounded_or_cancellable(self):
+        root = Path(__file__).resolve().parents[1] / "rta_brain"
+        for name in ("capture_daemon.py", "continuity_daemon.py"):
+            tree = ast.parse((root / name).read_text(encoding="utf-8"))
+            lease_calls = [
+                node
+                for node in ast.walk(tree)
+                if isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "database_writer_lease"
+            ]
+            self.assertTrue(lease_calls, name)
+            for call in lease_calls:
+                keywords = {item.arg for item in call.keywords}
+                self.assertTrue(
+                    {"timeout_seconds", "stop_requested"} & keywords,
+                    f"unbounded writer wait in {name}:{call.lineno}",
+                )
+
+    def test_continuity_discovers_sessions_before_requesting_writer_turn(self):
+        source = (
+            Path(__file__).resolve().parents[1] / "rta_brain" / "continuity_daemon.py"
+        ).read_text(encoding="utf-8")
+        worker = source.split("def run_continuity_worker", 1)[1]
+        loop = worker.split("while not stopping_requested():", 1)[1].split(
+            "stop_event.wait", 1
+        )[0]
+        self.assertLess(
+            loop.index("discover_codex_sessions("),
+            loop.index("with database_writer_lease("),
+        )
+
+    def test_watcher_defers_writer_turn_until_ingest_commit(self):
+        source = Path(__file__).resolve().parents[1] / "rta_brain" / "watch_daemon.py"
+        tree = ast.parse(source.read_text(encoding="utf-8"))
+        ingest_calls = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "ingest_repo"
+        ]
+
+        self.assertEqual(len(ingest_calls), 1)
+        keywords = {item.arg: item.value for item in ingest_calls[0].keywords}
+        self.assertIn("_writer_lease_factory", keywords)
+        self.assertIn("_initialize_schema", keywords)
+        self.assertIsInstance(keywords["_initialize_schema"], ast.Constant)
+        self.assertFalse(keywords["_initialize_schema"].value)
+
+    def test_writer_connections_bound_automatic_wal_growth(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            database = Path(tmp) / "brain.sqlite"
+            conn = db.connect(database)
+            try:
+                self.assertEqual(int(conn.execute("PRAGMA wal_autocheckpoint").fetchone()[0]), 4_096)
+                self.assertEqual(int(conn.execute("PRAGMA journal_size_limit").fetchone()[0]), 64 * 1024 * 1024)
+            finally:
+                conn.close()
+
+    def test_ingest_acquires_writer_lease_after_repository_preparation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            root.mkdir()
+            (root / "main.py").write_text("VALUE = 1\n", encoding="utf-8")
+            database = Path(tmp) / "brain.sqlite"
+            conn = db.connect(database)
+            db.ensure_project(conn, "demo", str(root))
+            events = []
+            original_manifest = db._repo_stat_manifest
+
+            def observed_manifest(*args, **kwargs):
+                events.append("manifest")
+                return original_manifest(*args, **kwargs)
+
+            @contextmanager
+            def observed_lease():
+                events.append("lease-enter")
+                try:
+                    yield {"wait_seconds": 0.0}
+                finally:
+                    events.append("lease-exit")
+
+            try:
+                with patch.object(db, "_repo_stat_manifest", side_effect=observed_manifest):
+                    result = db.ingest_repo(
+                        conn,
+                        root,
+                        project="demo",
+                        _writer_lease_factory=observed_lease,
+                        _initialize_schema=False,
+                    )
+            finally:
+                conn.close()
+
+            self.assertEqual(result["updated_files"], 1)
+            self.assertEqual(events, ["manifest", "lease-enter", "lease-exit"])
+
+    def test_unchanged_ingest_does_not_acquire_writer_lease(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            root.mkdir()
+            (root / "main.py").write_text("VALUE = 1\n", encoding="utf-8")
+            database = Path(tmp) / "brain.sqlite"
+            conn = db.connect(database)
+            events = []
+
+            @contextmanager
+            def observed_lease():
+                events.append("lease-enter")
+                try:
+                    yield {"wait_seconds": 0.0}
+                finally:
+                    events.append("lease-exit")
+
+            try:
+                db.ingest_repo(conn, root, project="demo")
+                result = db.ingest_repo(
+                    conn,
+                    root,
+                    project="demo",
+                    _writer_lease_factory=observed_lease,
+                    _initialize_schema=False,
+                )
+            finally:
+                conn.close()
+
+            self.assertTrue(result["manifest_unchanged"])
+            self.assertEqual(events, [])
+
+    def test_bounded_wal_checkpoint_is_passive_and_reports_outcome(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            database = Path(tmp) / "brain.sqlite"
+            conn = db.connect(database)
+            try:
+                conn.execute("CREATE TABLE checkpoint_probe(value TEXT NOT NULL)")
+                conn.execute("INSERT INTO checkpoint_probe(value) VALUES ('ready')")
+                conn.commit()
+                result = db.bounded_wal_checkpoint(conn, database, threshold_bytes=0)
+            finally:
+                conn.close()
+            self.assertEqual(result["mode"], "passive+truncate")
+            self.assertTrue(result["attempted"])
+            self.assertGreaterEqual(result["checkpointed_frames"], 0)
+            self.assertEqual(result["remaining_bytes"], 0)
+            self.assertTrue(result["bounded"])
+
+    def test_database_writer_lease_serializes_background_writers(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            database = Path(tmp) / "brain.sqlite"
+            database.write_bytes(b"database-placeholder")
+            first_entered = threading.Event()
+            release_first = threading.Event()
+            second_entered = threading.Event()
+            order = []
+
+            def first_writer():
+                with database_writer_lease(database, timeout_seconds=2):
+                    order.append("first-enter")
+                    first_entered.set()
+                    release_first.wait(timeout=2)
+                    order.append("first-exit")
+
+            def second_writer():
+                first_entered.wait(timeout=2)
+                with database_writer_lease(database, timeout_seconds=2):
+                    order.append("second-enter")
+                    second_entered.set()
+
+            first = threading.Thread(target=first_writer)
+            second = threading.Thread(target=second_writer)
+            first.start()
+            second.start()
+            self.assertTrue(first_entered.wait(timeout=2))
+            time.sleep(0.1)
+            self.assertFalse(second_entered.is_set())
+            release_first.set()
+            first.join(timeout=2)
+            second.join(timeout=2)
+            self.assertFalse(first.is_alive())
+            self.assertFalse(second.is_alive())
+            self.assertEqual(order, ["first-enter", "first-exit", "second-enter"])
+
+    def test_database_writer_lease_serves_waiters_in_fifo_order(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            database = Path(tmp) / "brain.sqlite"
+            database.write_bytes(b"database-placeholder")
+            holder_entered = threading.Event()
+            release_holder = threading.Event()
+            waiter_waiting = [threading.Event() for _ in range(3)]
+            entered = []
+
+            def holder():
+                with database_writer_lease(database, timeout_seconds=3):
+                    holder_entered.set()
+                    release_holder.wait(timeout=3)
+
+            def waiter(index: int):
+                with database_writer_lease(
+                    database,
+                    timeout_seconds=3,
+                    on_wait=lambda _waited: waiter_waiting[index].set(),
+                ):
+                    entered.append(index)
+                    time.sleep(0.05)
+
+            holder_thread = threading.Thread(target=holder)
+            holder_thread.start()
+            self.assertTrue(holder_entered.wait(timeout=2))
+            waiter_threads = []
+            for index in range(3):
+                thread = threading.Thread(target=waiter, args=(index,))
+                waiter_threads.append(thread)
+                thread.start()
+                self.assertTrue(waiter_waiting[index].wait(timeout=2))
+
+            control_dir = database.parent / ".rta-smriti-daemons"
+            queued_tickets = list(control_dir.glob("*.writer.*.ticket"))
+            release_holder.set()
+            holder_thread.join(timeout=3)
+            for thread in waiter_threads:
+                thread.join(timeout=3)
+
+            self.assertFalse(holder_thread.is_alive())
+            self.assertTrue(all(not thread.is_alive() for thread in waiter_threads))
+            self.assertEqual(len(queued_tickets), 3)
+            self.assertEqual(entered, [0, 1, 2])
+            self.assertEqual(list(control_dir.glob("*.writer.*.ticket")), [])
+
+    def test_database_writer_lease_is_released_after_a_crash_boundary(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            database = Path(tmp) / "brain.sqlite"
+            database.write_bytes(b"database-placeholder")
+            with (
+                self.assertRaisesRegex(RuntimeError, "simulated crash"),
+                database_writer_lease(database, timeout_seconds=1),
+            ):
+                raise RuntimeError("simulated crash")
+            with database_writer_lease(database, timeout_seconds=1) as receipt:
+                self.assertGreaterEqual(receipt["wait_seconds"], 0)
+
+    def test_database_writer_lease_is_released_after_process_termination(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(__file__).resolve().parents[1]
+            database = Path(tmp) / "brain.sqlite"
+            marker = Path(tmp) / "locked"
+            database.write_bytes(b"database-placeholder")
+            child = subprocess.Popen(
+                [
+                    sys.executable,
+                    "-c",
+                    (
+                        "import time; from pathlib import Path; "
+                        "from rta_brain.runtime_control import database_writer_lease; "
+                        f"database=Path({str(database)!r}); marker=Path({str(marker)!r}); "
+                        "lease=database_writer_lease(database, timeout_seconds=2); "
+                        "lease.__enter__(); marker.write_text('ready', encoding='ascii'); "
+                        "time.sleep(30)"
+                    ),
+                ],
+                cwd=root,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            try:
+                deadline = time.monotonic() + 5
+                while not marker.is_file() and time.monotonic() < deadline:
+                    time.sleep(0.025)
+                self.assertTrue(marker.is_file())
+                with (
+                    self.assertRaisesRegex(TimeoutError, "writer lease timed out"),
+                    database_writer_lease(database, timeout_seconds=0.1),
+                ):
+                    pass
+                control_dir = database.parent / ".rta-smriti-daemons"
+                self.assertEqual(list(control_dir.glob("*.writer.*.ticket")), [])
+            finally:
+                child.kill()
+                child.wait(timeout=5)
+            with database_writer_lease(database, timeout_seconds=1) as receipt:
+                self.assertGreaterEqual(receipt["wait_seconds"], 0)
+
+    def test_database_writer_lease_removes_a_crashed_waiter_ticket(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(__file__).resolve().parents[1]
+            database = Path(tmp) / "brain.sqlite"
+            marker = Path(tmp) / "waiting"
+            database.write_bytes(b"database-placeholder")
+            holder_entered = threading.Event()
+            release_holder = threading.Event()
+
+            def holder():
+                with database_writer_lease(database, timeout_seconds=3):
+                    holder_entered.set()
+                    release_holder.wait(timeout=3)
+
+            holder_thread = threading.Thread(target=holder)
+            holder_thread.start()
+            self.assertTrue(holder_entered.wait(timeout=2))
+            child = subprocess.Popen(
+                [
+                    sys.executable,
+                    "-c",
+                    (
+                        "from pathlib import Path; "
+                        "from rta_brain.runtime_control import database_writer_lease; "
+                        f"database=Path({str(database)!r}); marker=Path({str(marker)!r}); "
+                        "lease=database_writer_lease(database, timeout_seconds=30, "
+                        "on_wait=lambda _waited: marker.write_text('ready', encoding='ascii')); "
+                        "lease.__enter__()"
+                    ),
+                ],
+                cwd=root,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            control_dir = database.parent / ".rta-smriti-daemons"
+            try:
+                deadline = time.monotonic() + 5
+                while not marker.is_file() and time.monotonic() < deadline:
+                    time.sleep(0.025)
+                self.assertTrue(marker.is_file())
+                self.assertEqual(len(list(control_dir.glob("*.writer.*.ticket"))), 1)
+                child.kill()
+                child.wait(timeout=5)
+                self.assertEqual(len(list(control_dir.glob("*.writer.*.ticket"))), 1)
+            finally:
+                if child.poll() is None:
+                    child.kill()
+                    child.wait(timeout=5)
+                release_holder.set()
+                holder_thread.join(timeout=3)
+
+            with database_writer_lease(database, timeout_seconds=1):
+                pass
+            self.assertEqual(list(control_dir.glob("*.writer.*.ticket")), [])
+
+    def test_writer_ticket_is_not_visible_until_payload_is_complete(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            control_dir = Path(tmp)
+            with (
+                patch.object(runtime_control, "process_identity", return_value="pid:1"),
+                patch.object(os, "replace", side_effect=OSError("simulated crash")),
+                self.assertRaisesRegex(OSError, "simulated crash"),
+            ):
+                runtime_control._create_writer_ticket(control_dir, "brain", "key")
+            self.assertEqual(list(control_dir.glob("*.ticket")), [])
+
+    def test_expired_writer_lease_never_attempts_the_os_lock(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            database = Path(tmp) / "brain.sqlite"
+            database.write_bytes(b"database-placeholder")
+            with (
+                patch.object(runtime_control, "_try_lock_descriptor") as try_lock,
+                self.assertRaisesRegex(TimeoutError, "writer lease timed out"),
+                database_writer_lease(database, timeout_seconds=0),
+            ):
+                pass
+            try_lock.assert_not_called()
+
+    def test_writer_lease_wait_can_be_cancelled(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            database = Path(tmp) / "brain.sqlite"
+            database.write_bytes(b"database-placeholder")
+            with (
+                self.assertRaisesRegex(InterruptedError, "writer lease was cancelled"),
+                database_writer_lease(database, stop_requested=lambda: True),
+            ):
+                pass
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_database_security.py
+++ b/tests/test_database_security.py
@@ -11,6 +11,16 @@ from rta_brain.db import connect, init_project, remember
 
 
 class DatabaseSecurityTests(unittest.TestCase):
+    def test_posix_readonly_parent_must_be_private_and_owned(self):
+        path = Path("brain-dir")
+        unsafe = mock.Mock(st_uid=1000, st_mode=stat.S_IFDIR | 0o770)
+        with (
+            mock.patch.object(db_module.os, "getuid", return_value=1000, create=True),
+            mock.patch.object(Path, "stat", return_value=unsafe),
+            self.assertRaisesRegex(PermissionError, "directory must be private"),
+        ):
+            db_module._validate_posix_private_directory(path)
+
     def test_posix_mode_hardening_does_not_touch_an_already_private_file(self):
         path = Path("brain.sqlite")
         with mock.patch.object(

--- a/tests/test_embeddings_security.py
+++ b/tests/test_embeddings_security.py
@@ -1,0 +1,22 @@
+import sys
+import types
+import unittest
+from unittest.mock import Mock, patch
+
+from rta_brain.embeddings import SentenceTransformerEmbeddingProvider
+
+
+class EmbeddingSecurityTests(unittest.TestCase):
+    def test_sentence_transformer_read_path_loads_local_files_only(self):
+        constructor = Mock()
+        module = types.SimpleNamespace(SentenceTransformer=constructor)
+        with patch.dict(sys.modules, {"sentence_transformers": module}):
+            provider = SentenceTransformerEmbeddingProvider(
+                "local-model", local_files_only=True
+            )
+        constructor.assert_called_once_with("local-model", local_files_only=True)
+        self.assertEqual(provider.model, "local-model")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_operator_feedback.py
+++ b/tests/test_operator_feedback.py
@@ -1,20 +1,111 @@
+import sqlite3
 import subprocess
 import tempfile
 import unittest
 from pathlib import Path
 
 from rta_brain import db
-from rta_brain.context import build_context_pack, build_continuation_prompt
 from rta_brain.console import scan_brain_databases
+from rta_brain.context import (
+    build_context_pack,
+    build_continuation_prompt,
+    estimate_tokens,
+)
 from rta_brain.ingest import walk_repo
 from rta_brain.project import bootstrap_project
 from rta_brain.repository import repository_state
-
 
 ROOT = Path(__file__).resolve().parents[1]
 
 
 class RtaBrainOperatorFeedbackTests(unittest.TestCase):
+    def test_context_pack_is_read_only_while_another_writer_is_active(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            root.mkdir()
+            (root / "README.md").write_text(
+                "# Demo\n\nVerified planning evidence.\n",
+                encoding="utf-8",
+            )
+            database = Path(tmp) / "brain.sqlite"
+            seed = db.connect(database)
+            try:
+                db.ingest_repo(seed, root, project="demo")
+            finally:
+                seed.close()
+
+            writer = db.connect(database)
+            reader = sqlite3.connect(f"{database.as_uri()}?mode=ro", uri=True)
+            reader.row_factory = sqlite3.Row
+            reader.execute("PRAGMA query_only = ON")
+            try:
+                writer.execute("BEGIN IMMEDIATE")
+                writer.execute(
+                    "UPDATE projects SET created_at = created_at WHERE name = ?",
+                    ("demo",),
+                )
+                pack = build_context_pack(
+                    reader,
+                    "Demo planning evidence",
+                    project="demo",
+                    limit=3,
+                    max_tokens=800,
+                )
+                self.assertIn("README.md", pack)
+            finally:
+                writer.rollback()
+                reader.close()
+                writer.close()
+
+            verify = db.connect(database)
+            try:
+                recall_count = verify.execute(
+                    "SELECT COUNT(*) FROM recall_logs"
+                ).fetchone()[0]
+                self.assertEqual(recall_count, 0)
+            finally:
+                verify.close()
+
+    def test_one_hundred_context_packs_do_not_write_recall_rows(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            root.mkdir()
+            (root / "README.md").write_text(
+                "# Demo\n\nRepeated context read evidence.\n",
+                encoding="utf-8",
+            )
+            database = Path(tmp) / "brain.sqlite"
+            seed = db.connect(database)
+            try:
+                db.ingest_repo(seed, root, project="demo")
+            finally:
+                seed.close()
+
+            for _ in range(100):
+                reader = sqlite3.connect(f"{database.as_uri()}?mode=ro", uri=True)
+                reader.row_factory = sqlite3.Row
+                reader.execute("PRAGMA query_only = ON")
+                try:
+                    pack = build_context_pack(
+                        reader,
+                        "Demo context read evidence",
+                        project="demo",
+                        limit=3,
+                        max_tokens=800,
+                    )
+                    self.assertIn("Rta-Smriti Context Pack", pack)
+                finally:
+                    reader.close()
+
+            verify = db.connect(database)
+            try:
+                recall_count = verify.execute(
+                    "SELECT COUNT(*) FROM recall_logs"
+                ).fetchone()[0]
+                self.assertEqual(recall_count, 0)
+            finally:
+                verify.close()
+
     def test_project_root_is_bound_and_cannot_silently_switch(self):
         with tempfile.TemporaryDirectory() as tmp:
             first = Path(tmp) / "canonical"
@@ -81,6 +172,66 @@ class RtaBrainOperatorFeedbackTests(unittest.TestCase):
                 self.assertIn("Remaining gaps: Dashboard warning", pack)
                 self.assertIn("Do not repeat: Do not rescan unrelated folders", prompt)
                 self.assertIn("Next action: Implement the operator banner", prompt)
+            finally:
+                conn.close()
+
+    def test_context_pack_abstains_when_distinctive_task_anchor_is_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "command-center"
+            root.mkdir()
+            (root / "README.md").write_text(
+                "# Command Center\n\nRun the beta campaign approval queue.\n",
+                encoding="utf-8",
+            )
+            conn = db.connect(Path(tmp) / "brain.sqlite")
+            try:
+                db.ingest_repo(conn, root, project="codex-command-center")
+                search_result = db.search(
+                    conn,
+                    "Continue the Governor beta campaign command center",
+                    project="codex-command-center",
+                )
+                self.assertEqual(
+                    search_result["retrieval"]["relevance"]["state"],
+                    "insufficient",
+                )
+                self.assertEqual(
+                    search_result["retrieval"]["relevance"]["reason"],
+                    "missing_distinctive_task_anchor",
+                )
+                pack = build_context_pack(
+                    conn,
+                    "Continue the Governor beta campaign command center",
+                    project="codex-command-center",
+                    max_tokens=256,
+                )
+                self.assertLessEqual(estimate_tokens(pack), 256)
+                self.assertIn("Retrieval relevance: insufficient", pack)
+                self.assertIn("Missing distinctive task anchors: governor", pack)
+                self.assertIn("Do not use this context pack to guide edits", pack)
+                self.assertNotIn("Run the beta campaign approval queue", pack)
+            finally:
+                conn.close()
+
+    def test_context_pack_keeps_evidence_when_distinctive_task_anchor_matches(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "governor-beta-campaign"
+            root.mkdir()
+            (root / "README.md").write_text(
+                "# Governor beta campaign\n\nThe approval queue is the operator entry point.\n",
+                encoding="utf-8",
+            )
+            conn = db.connect(Path(tmp) / "brain.sqlite")
+            try:
+                db.ingest_repo(conn, root, project="governor-beta-campaign")
+                pack = build_context_pack(
+                    conn,
+                    "Continue the Governor beta campaign approval queue",
+                    project="governor-beta-campaign",
+                )
+                self.assertIn("Retrieval relevance: sufficient", pack)
+                self.assertIn("The approval queue is the operator entry point", pack)
+                self.assertNotIn("Do not use this context pack to guide edits", pack)
             finally:
                 conn.close()
 


### PR DESCRIPTION
## Summary
- add FIFO writer admission, cancellation-aware shutdown, and bounded WAL maintenance
- route retrieval through hardened read-only connections and reject stale deployment mirrors
- move optional Ollama compaction outside the shared writer lease and harden Windows Unicode output
- add concurrency, security, lifecycle, and operator regressions plus aligned documentation

## Verification
- 1,257 tests passed, 30 skipped, 704 subtests passed
- package build, Twine, install/upgrade/rollback/uninstall lifecycle passed
- privacy scan, Gitleaks, Bandit high-severity gate, actionlint, compileall, and repository dependency audit passed
- fresh Codex task opened schema v12 and completed direct MCP read-only search using installed 1.1.0a4 in isolated mode

## Disclosure
The post-fix Codex Deep Scan transport did not return a sealable report after two attempts. Its earlier scan's sole medium finding, optional model compaction under the writer lease, is fixed and regression-tested; this PR does not claim the post-fix Deep Scan passed.