### PR TITLE
fix: retain FIFO ticket through writer lease

### DIFF
--- a/rta_brain/runtime_control.py
+++ b/rta_brain/runtime_control.py
@@ -82,8 +82,6 @@ def database_writer_lease(
                     raise TimeoutError(
                         f"database writer lease timed out after {waited:.1f} seconds"
                     )
-                _remove_writer_ticket(ticket_path)
-                ticket_path = None
                 break
             if on_wait is not None and (last_notice < 0 or waited - last_notice >= 1.0):
                 on_wait(waited)
@@ -179,7 +177,7 @@ def _read_writer_ticket(ticket_path: Path) -> dict:
         raise ValueError(f"database writer ticket is oversized: {ticket_path}")
     flags = os.O_RDONLY | int(getattr(os, "O_CLOEXEC", 0))
     flags |= int(getattr(os, "O_NOFOLLOW", 0))
-    descriptor = os.open(ticket_path, flags)
+    descriptor = _open_writer_ticket_for_read(ticket_path, flags)
     try:
         opened = os.fstat(descriptor)
         if (
@@ -200,12 +198,40 @@ def _read_writer_ticket(ticket_path: Path) -> dict:
 
 
 def _remove_writer_ticket(ticket_path: Path) -> None:
-    try:
-        if ticket_path.exists() and not is_safe_regular_file(ticket_path):
-            raise ValueError(f"database writer ticket is linked or unsafe: {ticket_path}")
-        ticket_path.unlink(missing_ok=True)
-    except FileNotFoundError:
-        pass
+    deadline = time.monotonic() + 1.0
+    while True:
+        try:
+            if ticket_path.exists() and not is_safe_regular_file(ticket_path):
+                raise ValueError(f"database writer ticket is linked or unsafe: {ticket_path}")
+            ticket_path.unlink(missing_ok=True)
+            return
+        except FileNotFoundError:
+            return
+        except PermissionError as exc:
+            if not _is_transient_windows_file_race(exc):
+                raise
+            if time.monotonic() >= deadline:
+                raise
+            time.sleep(0.025)
+
+
+def _open_writer_ticket_for_read(ticket_path: Path, flags: int) -> int:
+    deadline = time.monotonic() + 1.0
+    while True:
+        try:
+            return os.open(ticket_path, flags)
+        except PermissionError as exc:
+            if not _is_transient_windows_file_race(exc):
+                raise
+            if time.monotonic() >= deadline:
+                raise
+            time.sleep(0.025)
+
+
+def _is_transient_windows_file_race(exc: PermissionError) -> bool:
+    return getattr(exc, "winerror", None) in {32, 33} or (
+        os.name == "nt" and exc.errno == errno.EACCES
+    )
 
 
 def _try_lock_descriptor(descriptor: int) -> bool:

--- a/tests/test_database_concurrency.py
+++ b/tests/test_database_concurrency.py
@@ -1,4 +1,5 @@
 import ast
+import errno
 import os
 import subprocess
 import sys
@@ -253,9 +254,61 @@ class DatabaseConcurrencyTests(unittest.TestCase):
 
             self.assertFalse(holder_thread.is_alive())
             self.assertTrue(all(not thread.is_alive() for thread in waiter_threads))
-            self.assertEqual(len(queued_tickets), 3)
+            # The active holder keeps its ticket published for the full
+            # critical section, so same-process Windows waiters cannot
+            # overtake it through process-scoped file-lock semantics.
+            self.assertEqual(len(queued_tickets), 4)
             self.assertEqual(entered, [0, 1, 2])
             self.assertEqual(list(control_dir.glob("*.writer.*.ticket")), [])
+
+    def test_writer_ticket_cleanup_retries_windows_sharing_violation(self):
+        sharing_violation = PermissionError(errno.EACCES, "sharing violation")
+        sharing_violation.winerror = 32
+        ticket_path = Path("writer.ticket")
+
+        with (
+            patch.object(Path, "exists", return_value=True),
+            patch.object(runtime_control, "is_safe_regular_file", return_value=True),
+            patch.object(
+                Path,
+                "unlink",
+                side_effect=[sharing_violation, None],
+            ) as unlink,
+            patch.object(runtime_control.time, "sleep") as sleep,
+        ):
+            runtime_control._remove_writer_ticket(ticket_path)
+
+        self.assertEqual(unlink.call_count, 2)
+        sleep.assert_called_once_with(0.025)
+
+    def test_writer_ticket_read_retries_windows_sharing_violation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ticket_path = Path(tmp) / "writer.ticket"
+            ticket_path.write_text(
+                '{"pid":1,"process_identity":"pid:1"}',
+                encoding="utf-8",
+            )
+            original_open = runtime_control.os.open
+            sharing_violation = PermissionError(errno.EACCES, "sharing violation")
+            sharing_violation.winerror = 32
+            attempts = 0
+
+            def flaky_open(*args, **kwargs):
+                nonlocal attempts
+                attempts += 1
+                if attempts == 1:
+                    raise sharing_violation
+                return original_open(*args, **kwargs)
+
+            with (
+                patch.object(runtime_control.os, "open", side_effect=flaky_open),
+                patch.object(runtime_control.time, "sleep") as sleep,
+            ):
+                payload = runtime_control._read_writer_ticket(ticket_path)
+
+        self.assertEqual(payload["process_identity"], "pid:1")
+        self.assertEqual(attempts, 2)
+        sleep.assert_called_once_with(0.025)
 
     def test_database_writer_lease_is_released_after_a_crash_boundary(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -303,7 +356,7 @@ class DatabaseConcurrencyTests(unittest.TestCase):
                 ):
                     pass
                 control_dir = database.parent / ".rta-smriti-daemons"
-                self.assertEqual(list(control_dir.glob("*.writer.*.ticket")), [])
+                self.assertEqual(len(list(control_dir.glob("*.writer.*.ticket"))), 1)
             finally:
                 child.kill()
                 child.wait(timeout=5)
@@ -350,10 +403,10 @@ class DatabaseConcurrencyTests(unittest.TestCase):
                 while not marker.is_file() and time.monotonic() < deadline:
                     time.sleep(0.025)
                 self.assertTrue(marker.is_file())
-                self.assertEqual(len(list(control_dir.glob("*.writer.*.ticket"))), 1)
+                self.assertEqual(len(list(control_dir.glob("*.writer.*.ticket"))), 2)
                 child.kill()
                 child.wait(timeout=5)
-                self.assertEqual(len(list(control_dir.glob("*.writer.*.ticket"))), 1)
+                self.assertEqual(len(list(control_dir.glob("*.writer.*.ticket"))), 2)
             finally:
                 if child.poll() is None:
                     child.kill()


### PR DESCRIPTION
## Summary
- retain each writer ticket for the full critical section so Windows same-process workers cannot overtake one another
- retry only bounded Windows ticket read/delete sharing races without weakening unsafe-file checks
- align crash and active-holder tests with the published-ticket invariant

## Verification
- focused managed-worker suite: 103 passed, 4 skipped, 7 subtests passed
- FIFO stress: 100/100 clean-process repetitions passed
- forced Windows read and cleanup race regressions passed
- context snapshot module: 49 passed, 21 subtests passed
- full suite: 1259 passed, 30 skipped, 704 subtests passed; one unrelated authorization test reported authorization_required after the 1h40 run, then passed in isolation and in its complete module
- privacy scan passed
- Gitleaks working-tree scan passed
- actionlint passed
- Ruff fatal-error gate passed
- Bandit high-severity gate passed
- compileall and git diff --check passed

## Scope
Exactly two public files. No private brain data, local paths, credentials, release tag, package version, or website content is included.