### PR TITLE
Fix isolated installed-runtime launchers

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -299,7 +299,9 @@ regex fallback, and Ed25519 signing work from the standard package.
 
 `install-local` remains available for existing alpha users and tests, but new
 installations should use the pip-generated commands above. Source wrappers are
-not required by an installed wheel.
+not required by an installed wheel. Compatibility wrappers remain isolated from
+the current working directory and are pinned to the exact installed package root
+that created them. Refresh the wrappers after moving or replacing that runtime.
 
 ## Upgrade An Existing Installation
 

--- a/rta_brain/mcp_host_lifecycle.py
+++ b/rta_brain/mcp_host_lifecycle.py
@@ -24,6 +24,7 @@ from typing import Any
 from .platform_paths import canonicalize_system_root_alias
 from .runtime_control import (
     create_secret,
+    isolated_module_bootstrap,
     is_safe_regular_file,
     prepare_control_dir,
     read_secret,
@@ -724,11 +725,7 @@ def _is_python_launcher(command: str, arguments: list[str]) -> bool:
     } or re.fullmatch(r"python\d+(?:\.\d+)*(?:\.exe)?", executable)
     if not python_name:
         return False
-    normalized = [item.casefold() for item in arguments]
-    for index, item in enumerate(normalized[:-1]):
-        if item == "-m" and normalized[index + 1] == "rta_brain.mcp_server":
-            return True
-    return False
+    return True
 
 
 def _path_is_within(path: Path, root: Path) -> bool:
@@ -808,6 +805,31 @@ def _canonicalize_launcher(
     executable = Path(command).name.casefold()
     python_launch = _is_python_launcher(command, arguments)
     if python_launch:
+        if isinstance(environment, Mapping):
+            forbidden = sorted(
+                key
+                for key in environment
+                if str(key).upper() in _FORBIDDEN_PYTHON_ENVIRONMENT
+            )
+            if forbidden:
+                raise ValueError(
+                    "MCP host Python launcher rejects import-path environment overrides"
+                )
+        if Path(command).is_absolute():
+            try:
+                if not os.path.samefile(Path(command), Path(sys.executable)):
+                    raise ValueError(
+                        "MCP host Python launcher must be the current authenticated runtime"
+                    )
+            except OSError as exc:
+                raise ValueError("MCP host Python launcher is missing") from exc
+        trusted_bootstrap = isolated_module_bootstrap(
+            "rta_brain.mcp_server", Path(__file__).resolve().parents[1]
+        )
+        if len(arguments) >= 3 and arguments[:2] == ["-I", "-c"]:
+            if arguments[2] != trusted_bootstrap:
+                raise ValueError("MCP host Python module launch shape is invalid")
+            return str(runtime_executable()), list(arguments), "python"
         module_indices = [
             index
             for index, item in enumerate(arguments[:-1])
@@ -822,24 +844,6 @@ def _canonicalize_launcher(
             raise ValueError(
                 "MCP host Python launcher permits only isolated mode before -m"
             )
-        if Path(command).is_absolute():
-            try:
-                if not os.path.samefile(Path(command), Path(sys.executable)):
-                    raise ValueError(
-                        "MCP host Python launcher must be the current authenticated runtime"
-                    )
-            except OSError as exc:
-                raise ValueError("MCP host Python launcher is missing") from exc
-        if isinstance(environment, Mapping):
-            forbidden = sorted(
-                key
-                for key in environment
-                if str(key).upper() in _FORBIDDEN_PYTHON_ENVIRONMENT
-            )
-            if forbidden:
-                raise ValueError(
-                    "MCP host Python launcher rejects import-path environment overrides"
-                )
         isolated_arguments = list(arguments)
         if not interpreter_prefix:
             isolated_arguments.insert(module_index, "-I")
@@ -1025,7 +1029,9 @@ def _redacted_value(value: str, *, previous_option: str | None = None) -> str:
         if _SECRET_OR_LOCAL_OPTION.search(option):
             digest = _digest_bytes(option_value.encode("utf-8"))[:12]
             return f"{option}=<redacted-local-value:{digest}>"
-    local_or_secret = bool(previous_option and _SECRET_OR_LOCAL_OPTION.search(previous_option))
+    local_or_secret = previous_option == "-c" or bool(
+        previous_option and _SECRET_OR_LOCAL_OPTION.search(previous_option)
+    )
     local_or_secret = local_or_secret or Path(value).is_absolute() or bool(
         re.match(r"^(?:~[/\\]|[A-Za-z]:[/\\])", value)
     )

--- a/rta_brain/project.py
+++ b/rta_brain/project.py
@@ -22,6 +22,7 @@ from .db import (
 )
 from .platform_paths import canonicalize_system_root_alias
 from .repository import RepositoryInspection
+from .runtime_control import isolated_module_bootstrap
 
 
 def _slug(value: str) -> str:
@@ -50,7 +51,12 @@ def _launch_parts(tool_root: Path, script_name: str, module_name: str) -> list[s
     script = tool_root / script_name
     if script.is_file():
         return [str(Path(sys.executable)), str(script)]
-    return [str(Path(sys.executable)), "-I", "-m", module_name]
+    return [
+        str(Path(sys.executable)),
+        "-I",
+        "-c",
+        isolated_module_bootstrap(module_name, tool_root),
+    ]
 
 
 def _shell_command(parts: list[str], shell: str | None = None) -> str:

--- a/rta_brain/runtime_control.py
+++ b/rta_brain/runtime_control.py
@@ -782,6 +782,18 @@ def detached_process_kwargs() -> dict:
     return {"start_new_session": True}
 
 
+def isolated_module_bootstrap(module: str, trusted_root: Path) -> str:
+    """Run one package module from an exact trusted root under isolated Python."""
+
+    root = json.dumps(str(trusted_root.resolve()), ensure_ascii=True)
+    selected_module = json.dumps(str(module), ensure_ascii=True)
+    return (
+        "import runpy,sys;"
+        f"sys.path.insert(0,{root});"
+        f"runpy.run_module({selected_module},run_name=\"__main__\")"
+    )
+
+
 def detached_worker_bootstrap(module: str, trusted_root: Path) -> str:
     statements = ["import os,runpy,sys"]
     if sys.platform == "darwin":

--- a/scripts/installed_distribution_smoke.py
+++ b/scripts/installed_distribution_smoke.py
@@ -306,7 +306,11 @@ def main() -> int:
                 project,
             ).stdout
         )["config"]["mcpServers"]["rta-smriti"]
-        if not Path(mcp["command"]).is_file() or mcp["args"][:3] != ["-I", "-m", "rta_brain.mcp_server"]:
+        if (
+            not Path(mcp["command"]).is_file()
+            or mcp["args"][:2] != ["-I", "-c"]
+            or "rta_brain.mcp_server" not in mcp["args"][2]
+        ):
             raise AssertionError(f"installed MCP command is invalid: {mcp}")
         mcp_probe = json.loads(
             run(

--- a/tests/test_mcp_host_lifecycle.py
+++ b/tests/test_mcp_host_lifecycle.py
@@ -797,6 +797,61 @@ class McpHostLifecycleTests(unittest.TestCase):
             "python",
         )
 
+    def test_exact_isolated_package_bootstrap_is_accepted_and_redacted(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / ".cursor" / "mcp.json"
+            target.parent.mkdir()
+            private_brain = str(Path(tmp) / "private" / "brains")
+            trusted_root = Path(mcp_host_lifecycle.__file__).resolve().parents[1]
+            bootstrap = (
+                "import runpy,sys;"
+                f"sys.path.insert(0,{json.dumps(str(trusted_root))});"
+                'runpy.run_module("rta_brain.mcp_server",run_name="__main__")'
+            )
+
+            plan = plan_host_configuration(
+                "cursor",
+                target,
+                "rta-smriti",
+                {
+                    "command": str(runtime_executable()),
+                    "args": [
+                        "-I",
+                        "-c",
+                        bootstrap,
+                        "--brain-dir",
+                        private_brain,
+                    ],
+                },
+            )
+
+            preview = plan["effective_configuration_change"]["server"]
+            self.assertEqual(preview["args"][:2], ["-I", "-c"])
+            self.assertRegex(
+                preview["args"][2], r"^<redacted-local-value:[0-9a-f]{12}>$"
+            )
+            serialized = json.dumps(plan, sort_keys=True)
+            self.assertNotIn(str(trusted_root), serialized)
+            self.assertNotIn(private_brain, serialized)
+
+    def test_arbitrary_python_code_is_not_accepted_as_an_mcp_launcher(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / ".cursor" / "mcp.json"
+            target.parent.mkdir()
+
+            with self.assertRaisesRegex(
+                ValueError, "MCP host Python module launch shape is invalid"
+            ):
+                plan_host_configuration(
+                    "cursor",
+                    target,
+                    "rta-smriti",
+                    {
+                        "command": str(runtime_executable()),
+                        "args": ["-I", "-c", "import os"],
+                    },
+                )
+
     def test_opencode_adapter_emits_current_documented_mcp_name_shape(self):
         with tempfile.TemporaryDirectory() as tmp:
             target = Path(tmp) / "opencode.json"

--- a/tests/test_project_usability.py
+++ b/tests/test_project_usability.py
@@ -200,7 +200,11 @@ class RtaBrainProjectUsabilityTests(unittest.TestCase):
             mcp = mcp_config_payload(str(db), "demo", "rta-smriti", installed_package_root)
             server = mcp["config"]["mcpServers"]["rta-smriti"]
             self.assertEqual(Path(server["command"]), Path(sys.executable))
-            self.assertEqual(server["args"][:3], ["-I", "-m", "rta_brain.mcp_server"])
+            self.assertEqual(server["args"][:2], ["-I", "-c"])
+            self.assertIn(
+                json.dumps(str(installed_package_root.resolve())), server["args"][2]
+            )
+            self.assertIn("rta_brain.mcp_server", server["args"][2])
 
             target = root / "bin"
             install_local(target, installed_package_root)
@@ -212,6 +216,38 @@ class RtaBrainProjectUsabilityTests(unittest.TestCase):
             self.assertIn("rta_brain.cli", cli_wrapper)
             self.assertIn("rta_brain.mcp_server", mcp_wrapper)
             self.assertNotIn("site-packages\\rta-brain.py", cli_wrapper)
+
+    def test_install_local_pins_isolated_wrappers_to_the_installed_package_root(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            installed_package_root = root / "user-site"
+            package = installed_package_root / "rta_brain"
+            package.mkdir(parents=True)
+            (package / "__init__.py").write_text("", encoding="utf-8")
+            (package / "cli.py").write_text(
+                'print("PINNED-USER-SITE")\n', encoding="utf-8"
+            )
+            (package / "mcp_server.py").write_text("", encoding="utf-8")
+            hostile = root / "hostile-cwd" / "rta_brain"
+            hostile.mkdir(parents=True)
+            (hostile / "__init__.py").write_text("", encoding="utf-8")
+            (hostile / "cli.py").write_text(
+                'print("HOSTILE-CWD")\n', encoding="utf-8"
+            )
+
+            target = root / "bin"
+            install_local(target, installed_package_root)
+            suffix = ".cmd" if os.name == "nt" else ""
+            completed = subprocess.run(
+                [str(target / f"rta-brain{suffix}")],
+                cwd=hostile.parent,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertEqual(completed.stdout.strip(), "PINNED-USER-SITE")
 
     def test_install_local_emits_posix_shell_wrappers(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -228,7 +264,8 @@ class RtaBrainProjectUsabilityTests(unittest.TestCase):
             self.assertEqual(Path(payload["wrappers"][1]).name, "rta-brain-mcp")
             wrapper = (target / "rta-brain").read_text(encoding="utf-8")
             self.assertTrue(wrapper.startswith("#!/bin/sh\n"))
-            self.assertIn("-I -m rta_brain.cli", wrapper)
+            self.assertIn(" -I -c ", wrapper)
+            self.assertIn("rta_brain.cli", wrapper)
             self.assertNotIn(".cmd", payload["shell_command"])
             self.assertIn("```bash", agent_text)
             self.assertNotIn("```powershell", agent_text)


### PR DESCRIPTION
## Summary
- pin compatibility CLI and MCP launchers to the exact installed package root while retaining Python isolated mode
- accept only the deterministic Rta-Smriti MCP bootstrap and redact its local package path from plan previews
- extend installed-distribution, hostile-working-directory, and MCP validation coverage

## Verification
- 1264 passed, 30 skipped, 704 subtests passed
- installed upgrade/rollback/re-upgrade/uninstall smoke passed
- 100/100 live context-pack reads under 27 active local writers, zero database locks
- npm unit tests and both production builds passed
- project-scoped pip-audit and npm audit: no known vulnerabilities
- privacy scan, Gitleaks, actionlint, compileall, install dry-run, and publish-readiness passed

No version bump, roadmap content, private brain data, or local project information is included.